### PR TITLE
Add Sanity webhook deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
             --overwrite
 
       - name: Purge CDN (if configured)
-        if: secrets.AZURE_CDN_ENDPOINT != ''
+        if: ${{ secrets.AZURE_CDN_ENDPOINT != '' }}
         run: |
           az cdn endpoint purge \
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow triggered by Sanity content publishes (via `repository_dispatch`) or manual trigger
- Builds the Astro site and uploads to Azure Blob Storage
- CDN purge step included (runs if CDN secrets are configured)

## Test plan
- [ ] Merge to main
- [ ] Run workflow manually from Actions tab
- [ ] Verify build succeeds and files land in Azure Blob Storage