### PR TITLE
Fix workflow paths for repo layout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: website
     steps:
       - uses: actions/checkout@v4
 
@@ -18,7 +15,6 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: website/package-lock.json
 
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
## Summary
- Removes `working-directory: website` and `cache-dependency-path` since the repo root is the website itself, not a monorepo
- Fixes the npm cache path resolution error in `actions/setup-node`