### PR TITLE
Fix Azure login to use creds JSON

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,9 +27,7 @@ jobs:
 
       - uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZURE_SPN_CLIENT_ID }}
-          client-secret: ${{ secrets.AZURE_SPN_SECRET }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Upload to Azure Blob Storage
         run: |


### PR DESCRIPTION
Uses AZURE_CREDENTIALS secret (JSON format) instead of separate client-id/client-secret inputs.