### PR TITLE
Switch to Albert Sans and Archivo fonts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Astro 6 static site for the Imperial College Algorithmic Trading Society. Must b
 | Framework | Astro 6 (static output), TypeScript |
 | Styling | Tailwind CSS 4 (PostCSS transformer) |
 | CMS | Sanity (hosted, project `bd3zp068`, dataset `production`) |
-| Fonts | Outfit (headings), Geist Sans (body), Geist Mono (code) |
+| Fonts | Archivo (headings), Albert Sans (body) |
 | Hosting | AWS Amplify (from `main` branch) |
 | Live chart | Canvas-based candlestick pulling from Yahoo Finance API |
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Astro + Sanity CMS rebuild of the ICATS website. Static output hosted on S3 + Cl
 | Framework | Astro 6 (static output), TypeScript strict |
 | Styling | Tailwind CSS 4 |
 | CMS | Sanity (hosted Studio at icats.sanity.studio) |
-| Fonts | Outfit (headings), Geist Sans (body), Geist Mono (code) |
+| Fonts | Archivo (headings), Albert Sans (body) |
 | Hosting | AWS S3 + CloudFront (static files) |
 | DNS | Route 53 |
 | CI/CD | GitHub Actions (build + deploy on content change) |

--- a/brand.md
+++ b/brand.md
@@ -40,8 +40,8 @@ Source of truth for colours and typography. CSS custom properties are defined in
 
 | Role | Font | CSS Variable | Applies to |
 |------|------|-------------|------------|
-| Display | Outfit (600, 700, 800) | `--font-display` | `h1`, `h2` |
-| Body | Geist Sans | `--font-sans` | Everything else |
-| Code | Geist Mono | `--font-mono` | Code snippets, data |
+| Display | Archivo (600, 700, 800) | `--font-display` | `h1`, `h2` |
+| Body | Albert Sans (300-700) | `--font-sans` | Everything else |
+| Code | System monospace | `--font-mono` | Code snippets, data |
 
-Outfit is loaded via Google Fonts in `BaseLayout.astro`. Geist Sans and Geist Mono are system-installed fallbacks.
+Both are loaded via Google Fonts in `BaseLayout.astro`.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -57,7 +57,7 @@ const fullTitle = title.includes("ICATS") ? title : `${title} | ICATS`;
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@600;700;800&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Albert+Sans:wght@300;400;500;600;700&family=Archivo:wght@600;700;800&display=swap" rel="stylesheet" />
     <ClientRouter />
   </head>
   <body class="min-h-full flex flex-col bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100">

--- a/src/pages/brand.astro
+++ b/src/pages/brand.astro
@@ -103,7 +103,7 @@ const colourGroups: { title: string; swatches: Swatch[] }[] = [
           <div class="flex items-baseline justify-between gap-4">
             <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Display</h3>
             <code class="text-xs bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded text-gray-600 dark:text-gray-400">
-              Outfit
+              Archivo
             </code>
           </div>
           <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Headings (h1, h2). Loaded via Google Fonts.</p>
@@ -116,10 +116,10 @@ const colourGroups: { title: string; swatches: Swatch[] }[] = [
           <div class="flex items-baseline justify-between gap-4">
             <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Sans</h3>
             <code class="text-xs bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded text-gray-600 dark:text-gray-400">
-              Geist Sans
+              Albert Sans
             </code>
           </div>
-          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Body text and UI elements.</p>
+          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Body text and UI elements. Loaded via Google Fonts.</p>
           <div class="mt-4 text-2xl">
             The quick brown fox jumps over the lazy dog
           </div>
@@ -132,10 +132,10 @@ const colourGroups: { title: string; swatches: Swatch[] }[] = [
           <div class="flex items-baseline justify-between gap-4">
             <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Mono</h3>
             <code class="text-xs bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded text-gray-600 dark:text-gray-400">
-              Geist Mono
+              System Monospace
             </code>
           </div>
-          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Code snippets, data, and technical content.</p>
+          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Code snippets, data, and technical content. Uses system monospace fonts.</p>
           <div class="mt-4 text-2xl" style="font-family: var(--font-mono)">
             The quick brown fox jumps over the lazy dog
           </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -26,9 +26,9 @@
   --color-brand-wit-pink: #E91E63;
 
   /* Typography */
-  --font-sans: 'Geist Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-  --font-mono: 'Geist Mono', ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
-  --font-display: 'Outfit', var(--font-sans), sans-serif;
+  --font-sans: 'Albert Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-mono: ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+  --font-display: 'Archivo', var(--font-sans), sans-serif;
 }
 
 body {


### PR DESCRIPTION
## Summary
- Replaces Outfit (headings) with **Archivo** and Geist Sans (body) with **Albert Sans**
- Both are free Google Fonts, chosen as close alternatives to the commercial Suisse Int'l and Neue Haas Grotesk Display requested by marketing
- Updates brand page, brand docs, CLAUDE.md, and README

## Test plan
- [ ] Verify fonts render correctly on the homepage and brand page
- [ ] Check Safari, Chrome, and Edge
- [ ] Test dark mode