### PR TITLE
Bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -25,7 +25,7 @@ jobs:
       # --- Deploy to Azure Blob Storage ---
       # Will migrate to AWS S3 in future.
 
-      - uses: azure/login@v2
+      - uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 


### PR DESCRIPTION
Updates checkout v4->v6, setup-node v4->v6, azure/login v2->v3 to resolve Node.js 20 deprecation warning.