### PR TITLE
Add QTC page, semantic colour tokens, and forced-dark design

### DIFF
--- a/brand.md
+++ b/brand.md
@@ -4,7 +4,7 @@ Source of truth for colours and typography. CSS custom properties are defined in
 
 ## Rules
 
-- Never hardcode hex colour values in components. Use Tailwind tokens (e.g. `bg-brand-navy`, `text-brand-gold`).
+- Never hardcode hex colour values in components. Use Tailwind tokens (e.g. `bg-brand-primary`, `text-brand-accent`).
 - To change a colour, edit `src/styles/globals.css` and rebuild.
 
 ## Colours
@@ -13,13 +13,19 @@ Source of truth for colours and typography. CSS custom properties are defined in
 
 | Token | Hex | Usage |
 |-------|-----|-------|
-| `brand-navy` | `#0F172A` | Nav, hero, footer backgrounds, headings |
-| `brand-dark` | `#0F172A` | Hover state for navy buttons |
-| `brand-dark-slate` | `#1E293B` | Gradient endpoints, secondary dark |
-| `brand-gold` | `#F59E0B` | CTAs, awards, premium accents |
-| `brand-green` | `#10B981` | Success states, data highlights |
-| `brand-light` | `#F8FAFC` | Section backgrounds (flips to `#111827` in dark mode) |
-| `brand-gray` | `#64748B` | Body text on light backgrounds |
+| `brand-primary` | `#2B2B2B` | Dark backgrounds, heading text on light surfaces |
+| `brand-slate` | `#1E293B` | Gradient endpoints, secondary dark |
+| `brand-accent` | `#F59E0B` | CTAs, awards, premium accents |
+| `brand-highlight` | `#10B981` | Success states, data highlights |
+| `brand-surface` | `#F8FAFC` | Section backgrounds (flips to `#111827` in dark mode) |
+| `brand-muted` | `#64748B` | Body text on light backgrounds |
+
+### Foreground (text on dark surfaces)
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| `brand-foreground` | `#E1E8EF` | Primary text on dark surfaces |
+| `brand-foreground-muted` | `#9CA3AF` | Muted/secondary text on dark surfaces |
 
 ### Purple Accent
 

--- a/src/components/content/MemberCard.astro
+++ b/src/components/content/MemberCard.astro
@@ -15,8 +15,8 @@ const linkProps = linkedIn ? { href: linkedIn, target: "_blank", rel: "noopener 
 ---
 
 <Tag {...linkProps}>
-  <div class="member-card relative bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-5 hover:shadow-md transition-shadow">
-    <div class="w-24 h-24 rounded-full overflow-hidden mb-4 bg-brand-light dark:bg-gray-800">
+  <div class="member-card relative bg-white/5 border border-white/10 rounded-xl p-5 hover:shadow-md transition-shadow">
+    <div class="w-24 h-24 rounded-full overflow-hidden mb-4 bg-white/5">
       {hasPhoto ? (
         <img
           src={photo}
@@ -27,20 +27,20 @@ const linkProps = linkedIn ? { href: linkedIn, target: "_blank", rel: "noopener 
           class="member-photo w-full h-full object-cover"
         />
         <div class="member-initials w-full h-full items-center justify-center" style="display:none">
-          <span class="text-xl font-bold text-brand-navy dark:text-white">{initials}</span>
+          <span class="text-xl font-bold text-brand-foreground">{initials}</span>
         </div>
       ) : (
         <div class="w-full h-full flex items-center justify-center">
-          <span class="text-xl font-bold text-brand-navy dark:text-white">{initials}</span>
+          <span class="text-xl font-bold text-brand-foreground">{initials}</span>
         </div>
       )}
     </div>
-    <h3 class="font-semibold text-brand-navy dark:text-white">{name}</h3>
-    <p class="text-sm text-gray-600 dark:text-gray-400 mt-0.5">{role}</p>
+    <h3 class="font-semibold text-brand-foreground">{name}</h3>
+    <p class="text-sm text-brand-foreground-muted mt-0.5">{role}</p>
     {bio && (
-      <div class="member-tooltip absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 bg-brand-navy text-gray-200 text-xs leading-relaxed rounded-lg px-4 py-3 shadow-lg pointer-events-none z-10">
+      <div class="member-tooltip absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 bg-brand-primary text-brand-foreground text-xs leading-relaxed rounded-lg px-4 py-3 shadow-lg pointer-events-none z-10">
         {bio}
-        <div class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-brand-navy" />
+        <div class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-brand-primary" />
       </div>
     )}
   </div>

--- a/src/components/content/SponsorLogo.astro
+++ b/src/components/content/SponsorLogo.astro
@@ -13,8 +13,8 @@ const Tag = websiteUrl ? "a" : "div";
 const linkProps = websiteUrl ? { href: websiteUrl, target: "_blank", rel: "noopener noreferrer" } : {};
 
 const cardClass = variant === "light"
-  ? "bg-white border border-gray-200"
-  : "bg-gray-50 dark:bg-white rounded-lg";
+  ? "bg-white/5 border border-white/20"
+  : "bg-white/10 rounded-lg";
 ---
 
 <Tag {...linkProps} class="sponsor-card relative group">
@@ -27,15 +27,15 @@ const cardClass = variant === "light"
         class="max-h-12 max-w-[140px] w-auto h-auto object-contain"
       />
     ) : (
-      <span class="text-sm font-semibold text-gray-500">{name}</span>
+      <span class="text-sm font-semibold text-brand-foreground-muted">{name}</span>
     )}
   </div>
-  <div class="sponsor-tooltip absolute bottom-full left-1/2 -translate-x-1/2 mb-2 bg-brand-navy text-white text-xs rounded-lg px-4 py-2.5 shadow-lg pointer-events-none z-10 w-48 text-center">
+  <div class="sponsor-tooltip absolute bottom-full left-1/2 -translate-x-1/2 mb-2 bg-brand-primary text-brand-foreground text-xs rounded-lg px-4 py-2.5 shadow-lg pointer-events-none z-10 w-48 text-center">
     <span class="font-semibold">{name}</span>
     {description && (
-      <p class="mt-1 text-gray-300 leading-relaxed">{description}</p>
+      <p class="mt-1 text-brand-foreground leading-relaxed">{description}</p>
     )}
-    <div class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-brand-navy" />
+    <div class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-brand-primary" />
   </div>
 </Tag>
 

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -2,11 +2,11 @@
 const year = new Date().getFullYear();
 ---
 
-<footer class="bg-brand-dark text-gray-400 mt-auto noise-overlay">
+<footer class="bg-brand-primary text-brand-foreground-muted mt-auto noise-overlay">
   <div class="relative z-10 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
       <div class="md:col-span-2">
-        <h3 class="text-lg font-bold text-white mb-2">ICATS</h3>
+        <h3 class="text-lg font-bold text-brand-foreground mb-2">ICATS</h3>
         <p class="text-sm leading-relaxed">
           Imperial College Algorithmic Trading Society. London's premier
           university society for aspiring traders, quant researchers, and
@@ -18,32 +18,32 @@ const year = new Date().getFullYear();
       </div>
 
       <div>
-        <h4 class="text-sm font-semibold text-white mb-3">Quick Links</h4>
+        <h4 class="text-sm font-semibold text-brand-foreground mb-3">Quick Links</h4>
         <ul class="space-y-2 text-sm">
-          <li><a href="/about" class="hover:text-white transition-colors">About</a></li>
-          <li><a href="/events" class="hover:text-white transition-colors">Events</a></li>
-          <li><a href="/programmes" class="hover:text-white transition-colors">Programmes</a></li>
-          <li><a href="/sponsors" class="hover:text-white transition-colors">Sponsors</a></li>
-          <li><a href="/wit" class="hover:text-white transition-colors">Women in Trading</a></li>
+          <li><a href="/about" class="hover:text-brand-foreground transition-colors">About</a></li>
+          <li><a href="/events" class="hover:text-brand-foreground transition-colors">Events</a></li>
+          <li><a href="/programmes" class="hover:text-brand-foreground transition-colors">Programmes</a></li>
+          <li><a href="/sponsors" class="hover:text-brand-foreground transition-colors">Sponsors</a></li>
+          <li><a href="/wit" class="hover:text-brand-foreground transition-colors">Women in Trading</a></li>
         </ul>
       </div>
 
       <div>
-        <h4 class="text-sm font-semibold text-white mb-3">Connect</h4>
+        <h4 class="text-sm font-semibold text-brand-foreground mb-3">Connect</h4>
         <ul class="space-y-2 text-sm">
           <li>
-            <a href="mailto:algo.trade@imperial.ac.uk" class="hover:text-white transition-colors">
+            <a href="mailto:algo.trade@imperial.ac.uk" class="hover:text-brand-foreground transition-colors">
               algo.trade@imperial.ac.uk
             </a>
           </li>
           <li>
-            <a href="https://www.linkedin.com/company/icalgosoc/" target="_blank" rel="noopener noreferrer" class="hover:text-white transition-colors">LinkedIn</a>
+            <a href="https://www.linkedin.com/company/icalgosoc/" target="_blank" rel="noopener noreferrer" class="hover:text-brand-foreground transition-colors">LinkedIn</a>
           </li>
           <li>
-            <a href="https://www.instagram.com/ic.algosoc/" target="_blank" rel="noopener noreferrer" class="hover:text-white transition-colors">Instagram</a>
+            <a href="https://www.instagram.com/ic.algosoc/" target="_blank" rel="noopener noreferrer" class="hover:text-brand-foreground transition-colors">Instagram</a>
           </li>
           <li>
-            <a href="/rss.xml" class="hover:text-white transition-colors">RSS Feed</a>
+            <a href="/rss.xml" class="hover:text-brand-foreground transition-colors">RSS Feed</a>
           </li>
         </ul>
       </div>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -2,12 +2,12 @@
 import { navItems } from "@/lib/data";
 ---
 
-<header class="sticky top-0 z-50 bg-brand-navy border-b border-white/10">
+<header class="sticky top-0 z-50 bg-brand-primary border-b border-white/10">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
     <div class="flex h-16 items-center justify-between">
       <a href="/" class="flex items-center gap-2">
-        <span class="text-xl font-bold text-white tracking-tight">ICATS</span>
-        <span class="hidden sm:inline text-sm text-brand-gray">
+        <span class="text-xl font-bold text-brand-foreground tracking-tight">ICATS</span>
+        <span class="hidden sm:inline text-sm text-brand-muted">
           Imperial College Algorithmic Trading Society
         </span>
       </a>
@@ -16,14 +16,14 @@ import { navItems } from "@/lib/data";
         {navItems.map((item) => (
           <a
             href={item.href}
-            class="px-3 py-2 text-sm text-gray-300 hover:text-white hover:bg-white/10 rounded-md transition-colors"
+            class="px-3 py-2 text-sm text-brand-foreground-muted hover:text-brand-foreground hover:bg-white/10 rounded-md transition-colors"
           >
             {item.label}
           </a>
         ))}
         <a
           href="/join"
-          class="ml-3 px-4 py-2 text-sm font-medium text-brand-navy bg-brand-gold hover:bg-amber-400 rounded-md transition-colors"
+          class="ml-3 px-4 py-2 text-sm font-medium text-brand-foreground bg-brand-accent hover:bg-amber-400 rounded-md transition-colors"
         >
           Join ICATS
         </a>
@@ -31,7 +31,7 @@ import { navItems } from "@/lib/data";
 
       <button
         id="mobile-toggle"
-        class="md:hidden text-gray-300 hover:text-white p-2"
+        class="md:hidden text-brand-foreground-muted hover:text-brand-foreground p-2"
         aria-label="Toggle menu"
         aria-expanded="false"
       >
@@ -45,19 +45,19 @@ import { navItems } from "@/lib/data";
     </div>
   </div>
 
-  <div id="mobile-menu" class="md:hidden bg-brand-navy border-t border-white/10 hidden">
+  <div id="mobile-menu" class="md:hidden bg-brand-primary border-t border-white/10 hidden">
     <div class="px-4 py-3 space-y-1">
       {navItems.map((item) => (
         <a
           href={item.href}
-          class="block px-3 py-2 text-sm text-gray-300 hover:text-white hover:bg-white/10 rounded-md"
+          class="block px-3 py-2 text-sm text-brand-foreground-muted hover:text-brand-foreground hover:bg-white/10 rounded-md"
         >
           {item.label}
         </a>
       ))}
       <a
         href="/join"
-        class="block mt-2 px-3 py-2 text-sm font-medium text-brand-navy bg-brand-gold hover:bg-amber-400 rounded-md text-center"
+        class="block mt-2 px-3 py-2 text-sm font-medium text-brand-foreground bg-brand-accent hover:bg-amber-400 rounded-md text-center"
       >
         Join ICATS
       </a>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,16 +3,18 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 ---
 
 <BaseLayout title="Page Not Found" description="The page you're looking for doesn't exist.">
-  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-32 text-center">
-    <h1 class="text-6xl font-bold text-brand-navy dark:text-white">404</h1>
-    <p class="mt-4 text-lg text-gray-600 dark:text-gray-400">
-      The page you're looking for doesn't exist.
-    </p>
-    <a
-      href="/"
-      class="inline-block mt-8 px-6 py-3 text-sm font-semibold bg-brand-navy text-white rounded-lg hover:bg-brand-dark transition-colors"
-    >
-      Back to Home
-    </a>
+  <div class="bg-brand-primary">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-32 text-center">
+      <h1 class="text-6xl font-bold text-brand-foreground">404</h1>
+      <p class="mt-4 text-lg text-brand-foreground-muted">
+        The page you're looking for doesn't exist.
+      </p>
+      <a
+        href="/"
+        class="inline-block mt-8 px-6 py-3 text-sm font-semibold bg-brand-accent text-brand-primary rounded-lg hover:bg-amber-400 transition-colors"
+      >
+        Back to Home
+      </a>
+    </div>
   </div>
 </BaseLayout>

--- a/src/pages/about/committee.astro
+++ b/src/pages/about/committee.astro
@@ -40,16 +40,17 @@ const witCommittee = members.filter((m) => m.division === "icwit");
   description="Meet the ICATS committee: the team running Imperial College's algorithmic trading society across trading, technology, events, marketing, and operations."
   canonical="/about/committee"
 >
-  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
-    <h1 class="text-3xl sm:text-4xl font-bold text-brand-navy dark:text-white">
+  <div class="bg-brand-primary">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+    <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
       Our Committees
     </h1>
-    <p class="mt-2 text-gray-600 dark:text-gray-400">
+    <p class="mt-2 text-brand-foreground-muted">
       The ICATS &amp; ICWiT committees driving our programmes, events, and
       partnerships.
     </p>
 
-    <h2 class="text-xl font-bold text-brand-navy dark:text-white mt-12 mb-6">
+    <h2 class="text-xl font-bold text-brand-foreground mt-12 mb-6">
       ICATS Leadership
     </h2>
     {committee.length > 0 ? (
@@ -59,10 +60,10 @@ const witCommittee = members.filter((m) => m.division === "icwit");
         ))}
       </div>
     ) : (
-      <p class="text-gray-500 dark:text-gray-400">Committee members will be announced soon.</p>
+      <p class="text-brand-foreground-muted">Committee members will be announced soon.</p>
     )}
 
-    <h2 class="text-xl font-bold text-brand-navy dark:text-white mt-16 mb-6">
+    <h2 class="text-xl font-bold text-brand-foreground mt-16 mb-6">
       ICWiT Leadership
     </h2>
     {witCommittee.length > 0 ? (
@@ -72,7 +73,8 @@ const witCommittee = members.filter((m) => m.division === "icwit");
         ))}
       </div>
     ) : (
-      <p class="text-gray-500 dark:text-gray-400">ICWiT committee members will be announced soon.</p>
+      <p class="text-brand-foreground-muted">ICWiT committee members will be announced soon.</p>
     )}
+    </div>
   </div>
 </BaseLayout>

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -10,11 +10,12 @@ const stats = await getStats();
   description="Learn about ICATS, Imperial College's algorithmic trading society. Our mission, history, and what we offer to aspiring quant traders and technologists."
   canonical="/about"
 >
-  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
-    <h1 class="text-3xl sm:text-4xl font-bold text-brand-navy dark:text-white">
+  <div class="bg-brand-primary">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+    <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
       About ICATS
     </h1>
-    <p class="mt-4 text-lg text-gray-600 dark:text-gray-400 max-w-3xl leading-relaxed">
+    <p class="mt-4 text-lg text-brand-foreground-muted max-w-3xl leading-relaxed">
       The Imperial College Algorithmic Trading Society (ICATS) is London&apos;s
       premier university society for students passionate about quantitative
       finance, algorithmic trading, and market technology. Founded in {stats.founded},
@@ -28,15 +29,15 @@ const stats = await getStats();
         { value: stats.eventsHosted, label: "Events per Year" },
         { value: stats.offers, label: "Offers Secured by Members" },
       ].map((s) => (
-        <div class="bg-brand-light dark:bg-gray-900/50 rounded-xl p-6 text-center">
-          <div class="text-2xl font-bold text-brand-navy dark:text-white">{s.value}</div>
-          <div class="text-sm text-gray-600 dark:text-gray-400 mt-1">{s.label}</div>
+        <div class="bg-white/5 rounded-xl p-6 text-center">
+          <div class="text-2xl font-bold text-brand-foreground">{s.value}</div>
+          <div class="text-sm text-brand-foreground-muted mt-1">{s.label}</div>
         </div>
       ))}
     </div>
 
-    <div class="mt-16 max-w-3xl space-y-6 text-gray-700 dark:text-gray-300 leading-relaxed">
-      <h2 class="text-2xl font-bold text-brand-navy dark:text-white">Our Mission</h2>
+    <div class="mt-16 max-w-3xl space-y-6 text-brand-foreground leading-relaxed">
+      <h2 class="text-2xl font-bold text-brand-foreground">Our Mission</h2>
       <p>
         We exist to bridge the gap between academic knowledge and industry
         practice. Through our educational programmes, flagship competitions,
@@ -45,12 +46,12 @@ const stats = await getStats();
         quantitative finance.
       </p>
 
-      <h2 class="text-2xl font-bold text-brand-navy dark:text-white mt-10">
+      <h2 class="text-2xl font-bold text-brand-foreground mt-10">
         What We Do
       </h2>
       <ul class="space-y-3">
         <li class="flex gap-3">
-          <span class="text-brand-gold font-bold">01</span>
+          <span class="text-brand-accent font-bold">01</span>
           <span>
             <strong>Educate</strong> - Bootcamp, AlgoCourse, Markets 101,
             and weekly quant sessions prepare members for careers and
@@ -58,7 +59,7 @@ const stats = await getStats();
           </span>
         </li>
         <li class="flex gap-3">
-          <span class="text-brand-gold font-bold">02</span>
+          <span class="text-brand-accent font-bold">02</span>
           <span>
             <strong>Compete</strong> - Algothon, Estimathon, and our internal
             QTC competition give members hands-on trading experience in
@@ -66,7 +67,7 @@ const stats = await getStats();
           </span>
         </li>
         <li class="flex gap-3">
-          <span class="text-brand-gold font-bold">03</span>
+          <span class="text-brand-accent font-bold">03</span>
           <span>
             <strong>Invest</strong> - Queen&apos;s Tower Capital is our
             student-managed quantitative fund, where analysts build and
@@ -75,7 +76,7 @@ const stats = await getStats();
           </span>
         </li>
         <li class="flex gap-3">
-          <span class="text-brand-gold font-bold">04</span>
+          <span class="text-brand-accent font-bold">04</span>
           <span>
             <strong>Connect</strong> - We partner with {stats.partners}{" "}
             leading firms to bring industry insight, career opportunities,
@@ -88,10 +89,11 @@ const stats = await getStats();
     <div class="mt-12">
       <a
         href="/about/committee"
-        class="inline-block px-6 py-3 text-sm font-semibold bg-brand-navy text-white rounded-lg hover:bg-brand-dark transition-colors"
+        class="inline-block px-6 py-3 text-sm font-semibold bg-brand-accent text-brand-primary rounded-lg hover:bg-amber-400 transition-colors"
       >
         Meet the Committee &rarr;
       </a>
+    </div>
     </div>
   </div>
 </BaseLayout>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -57,46 +57,48 @@ const articleJsonLd = {
   canonical={`/blog/${slug}`}
   ogType="article"
 >
-  <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-16">
+  <div class="bg-brand-primary">
+    <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-16">
     <script type="application/ld+json" set:html={JSON.stringify(articleJsonLd)} />
 
     <div class="flex items-center gap-3 mb-4">
       <span
         class={`px-2.5 py-0.5 text-xs font-medium rounded-full ${
-          blogCategoryColours[category] || "bg-gray-100 text-gray-700"
+          blogCategoryColours[category] || "bg-white/10 text-brand-foreground"
         }`}
       >
         {blogCategoryLabels[category] || category}
       </span>
       {formatted && (
-        <span class="text-sm text-gray-500 dark:text-gray-400">{formatted}</span>
+        <span class="text-sm text-brand-foreground-muted">{formatted}</span>
       )}
     </div>
 
-    <h1 class="text-3xl sm:text-4xl font-bold text-brand-navy dark:text-white">
+    <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
       {post.title}
     </h1>
 
     {post.author && (
-      <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">By {post.author}</p>
+      <p class="mt-3 text-sm text-brand-foreground-muted">By {post.author}</p>
     )}
 
     {contentHtml ? (
       <div
-        class="mt-8 prose prose-gray dark:prose-invert max-w-none"
+        class="mt-8 prose prose-gray max-w-none"
         set:html={contentHtml}
       />
     ) : post.excerpt ? (
-      <p class="mt-8 text-gray-600 dark:text-gray-400 leading-relaxed">{post.excerpt}</p>
+      <p class="mt-8 text-brand-foreground-muted leading-relaxed">{post.excerpt}</p>
     ) : null}
 
-    <div class="mt-12 pt-8 border-t border-gray-200 dark:border-gray-800">
+    <div class="mt-12 pt-8 border-t border-white/10">
       <a
         href="/blog"
-        class="text-sm font-medium text-brand-gold hover:underline"
+        class="text-sm font-medium text-brand-accent hover:underline"
       >
         &larr; Back to blog
       </a>
+    </div>
     </div>
   </div>
 </BaseLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -25,15 +25,16 @@ const posts = allPosts
   description="ICATS blog: market recaps, research articles, newsletters, and announcements from Imperial College's algorithmic trading society."
   canonical="/blog"
 >
-  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
-    <h1 class="text-3xl sm:text-4xl font-bold text-brand-navy dark:text-white">Blog</h1>
-    <p class="mt-2 text-gray-600 dark:text-gray-400 max-w-xl">
+  <div class="bg-brand-primary">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+      <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">Blog</h1>
+    <p class="mt-2 text-brand-foreground-muted max-w-xl">
       Weekly market recaps, research notes, and newsletters from the ICATS
       committee.
     </p>
 
     {posts.length === 0 ? (
-      <p class="mt-10 text-gray-500 dark:text-gray-400">No posts yet. Check back soon.</p>
+      <p class="mt-10 text-brand-foreground-muted">No posts yet. Check back soon.</p>
     ) : (
       <div class="mt-8 space-y-6">
         {posts.map((post) => {
@@ -43,35 +44,36 @@ const posts = allPosts
           return (
             <a
               href={`/blog/${post.slug.current}`}
-              class="group block bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-6 hover:shadow-md hover:border-brand-gold/30 transition-all"
+              class="group block bg-white/5 border border-white/10 rounded-xl p-6 hover:shadow-md hover:border-brand-accent/30 transition-all"
             >
               <div class="flex items-center gap-3 mb-2">
                 <span
                   class={`px-2.5 py-0.5 text-xs font-medium rounded-full ${
-                    blogCategoryColours[category] || "bg-gray-100 text-gray-700"
+                    blogCategoryColours[category] || "bg-white/10 text-brand-foreground"
                   }`}
                 >
                   {blogCategoryLabels[category] || category}
                 </span>
                 {formatted && (
-                  <span class="text-xs text-gray-500 dark:text-gray-400">{formatted}</span>
+                  <span class="text-xs text-brand-foreground-muted">{formatted}</span>
                 )}
               </div>
-              <h2 class="text-lg font-semibold text-brand-navy dark:text-white group-hover:text-brand-gold transition-colors">
+              <h2 class="text-lg font-semibold text-brand-foreground group-hover:text-brand-accent transition-colors">
                 {post.title}
               </h2>
               {post.excerpt && (
-                <p class="mt-2 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+                <p class="mt-2 text-sm text-brand-foreground-muted leading-relaxed">
                   {post.excerpt}
                 </p>
               )}
               {post.author && (
-                <p class="mt-3 text-xs text-gray-500 dark:text-gray-400">By {post.author}</p>
+                <p class="mt-3 text-xs text-brand-foreground-muted">By {post.author}</p>
               )}
             </a>
           );
         })}
       </div>
     )}
+    </div>
   </div>
 </BaseLayout>

--- a/src/pages/brand.astro
+++ b/src/pages/brand.astro
@@ -16,10 +16,10 @@ const colourGroups: { title: string; swatches: Swatch[] }[] = [
   {
     title: "Core",
     swatches: [
-      { name: "Navy", hex: "#0F172A", cssVar: "--color-brand-navy", description: "Nav, hero, footer backgrounds, headings" },
-      { name: "Dark Slate", hex: "#1E293B", cssVar: "--color-brand-dark-slate", description: "Gradient endpoints, secondary dark" },
-      { name: "Gold", hex: "#F59E0B", cssVar: "--color-brand-gold", description: "CTAs, awards, premium accents" },
-      { name: "Green", hex: "#10B981", cssVar: "--color-brand-green", description: "Success states, data highlights" },
+      { name: "Primary", hex: "#2B2B2B", cssVar: "--color-brand-primary", description: "Dark backgrounds, heading text on light surfaces" },
+      { name: "Slate", hex: "#1E293B", cssVar: "--color-brand-slate", description: "Gradient endpoints, secondary dark" },
+      { name: "Accent", hex: "#F59E0B", cssVar: "--color-brand-accent", description: "CTAs, awards, premium accents" },
+      { name: "Highlight", hex: "#10B981", cssVar: "--color-brand-highlight", description: "Success states, data highlights" },
     ],
   },
   {
@@ -40,8 +40,10 @@ const colourGroups: { title: string; swatches: Swatch[] }[] = [
   {
     title: "Neutrals",
     swatches: [
-      { name: "Light", hex: "#F8FAFC", cssVar: "--color-brand-light", description: "Section backgrounds" },
-      { name: "Gray", hex: "#64748B", cssVar: "--color-brand-gray", description: "Body text on light backgrounds" },
+      { name: "Surface", hex: "#F8FAFC", cssVar: "--color-brand-surface", description: "Section backgrounds" },
+      { name: "Muted", hex: "#64748B", cssVar: "--color-brand-muted", description: "Body text on light backgrounds" },
+      { name: "Foreground", hex: "#E1E8EF", cssVar: "--color-brand-foreground", description: "Primary text on dark surfaces" },
+      { name: "Foreground Muted", hex: "#9CA3AF", cssVar: "--color-brand-foreground-muted", description: "Muted text on dark surfaces" },
     ],
   },
 ];
@@ -53,39 +55,39 @@ const colourGroups: { title: string; swatches: Swatch[] }[] = [
   canonical="/brand"
 >
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
-    <h1 class="text-3xl sm:text-4xl font-bold text-gray-900 dark:text-gray-100">
+    <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
       ICATS Brand Guidelines
     </h1>
-    <p class="mt-2 text-gray-600 dark:text-gray-400 max-w-2xl">
+    <p class="mt-2 text-brand-foreground-muted max-w-2xl">
       Single source of truth for colours, typography, and visual identity
       across all ICATS and ICWiT materials. Defined in
-      <code class="text-sm bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded">src/styles/globals.css</code>.
+      <code class="text-sm bg-white/10 px-1.5 py-0.5 rounded">src/styles/globals.css</code>.
     </p>
 
     {/* Colours */}
     <section class="mt-16">
-      <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Colours</h2>
+      <h2 class="text-2xl font-bold text-brand-foreground">Colours</h2>
 
       {colourGroups.map((group) => (
         <div class="mt-8">
-          <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">{group.title}</h3>
+          <h3 class="text-lg font-semibold text-brand-foreground mb-4">{group.title}</h3>
           <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
             {group.swatches.map((s) => (
-              <div class="border border-gray-200 dark:border-gray-800 rounded-xl overflow-hidden">
+              <div class="border border-white/10 rounded-xl overflow-hidden">
                 <div
                   class="h-24 flex items-end p-3"
                   style={`background-color: ${s.hex}`}
                 >
                   <span
-                    class={`text-xs font-mono font-medium ${isLight(s.hex) ? "text-gray-900" : "text-white"}`}
+                    class={`text-xs font-mono font-medium ${isLight(s.hex) ? "text-brand-foreground" : "text-brand-foreground"}`}
                   >
                     {s.hex}
                   </span>
                 </div>
                 <div class="p-3">
-                  <h4 class="text-sm font-semibold text-gray-900 dark:text-gray-100">{s.name}</h4>
-                  <code class="text-xs text-gray-400">{s.cssVar}</code>
-                  <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{s.description}</p>
+                  <h4 class="text-sm font-semibold text-brand-foreground">{s.name}</h4>
+                  <code class="text-xs text-brand-foreground-muted">{s.cssVar}</code>
+                  <p class="text-xs text-brand-foreground-muted mt-0.5">{s.description}</p>
                 </div>
               </div>
             ))}
@@ -96,50 +98,50 @@ const colourGroups: { title: string; swatches: Swatch[] }[] = [
 
     {/* Typography */}
     <section class="mt-16">
-      <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Typography</h2>
+      <h2 class="text-2xl font-bold text-brand-foreground">Typography</h2>
 
       <div class="mt-6 space-y-6">
-        <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-6">
+        <div class="bg-white/5 border border-white/10 rounded-xl p-6">
           <div class="flex items-baseline justify-between gap-4">
-            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Display</h3>
-            <code class="text-xs bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded text-gray-600 dark:text-gray-400">
+            <h3 class="text-lg font-semibold text-brand-foreground">Display</h3>
+            <code class="text-xs bg-white/10 px-2 py-1 rounded text-brand-foreground-muted">
               Archivo
             </code>
           </div>
-          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Headings (h1, h2). Loaded via Google Fonts.</p>
+          <p class="text-sm text-brand-foreground-muted mt-1">Headings (h1, h2). Loaded via Google Fonts.</p>
           <div class="mt-4 text-2xl" style="font-family: var(--font-display)">
             The quick brown fox jumps over the lazy dog
           </div>
         </div>
 
-        <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-6">
+        <div class="bg-white/5 border border-white/10 rounded-xl p-6">
           <div class="flex items-baseline justify-between gap-4">
-            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Sans</h3>
-            <code class="text-xs bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded text-gray-600 dark:text-gray-400">
+            <h3 class="text-lg font-semibold text-brand-foreground">Sans</h3>
+            <code class="text-xs bg-white/10 px-2 py-1 rounded text-brand-foreground-muted">
               Albert Sans
             </code>
           </div>
-          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Body text and UI elements. Loaded via Google Fonts.</p>
+          <p class="text-sm text-brand-foreground-muted mt-1">Body text and UI elements. Loaded via Google Fonts.</p>
           <div class="mt-4 text-2xl">
             The quick brown fox jumps over the lazy dog
           </div>
-          <div class="mt-2 text-lg text-gray-600 dark:text-gray-400">
+          <div class="mt-2 text-lg text-brand-foreground-muted">
             ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz 0123456789
           </div>
         </div>
 
-        <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-6">
+        <div class="bg-white/5 border border-white/10 rounded-xl p-6">
           <div class="flex items-baseline justify-between gap-4">
-            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Mono</h3>
-            <code class="text-xs bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded text-gray-600 dark:text-gray-400">
+            <h3 class="text-lg font-semibold text-brand-foreground">Mono</h3>
+            <code class="text-xs bg-white/10 px-2 py-1 rounded text-brand-foreground-muted">
               System Monospace
             </code>
           </div>
-          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Code snippets, data, and technical content. Uses system monospace fonts.</p>
+          <p class="text-sm text-brand-foreground-muted mt-1">Code snippets, data, and technical content. Uses system monospace fonts.</p>
           <div class="mt-4 text-2xl" style="font-family: var(--font-mono)">
             The quick brown fox jumps over the lazy dog
           </div>
-          <div class="mt-2 text-lg text-gray-600 dark:text-gray-400" style="font-family: var(--font-mono)">
+          <div class="mt-2 text-lg text-brand-foreground-muted" style="font-family: var(--font-mono)">
             ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz 0123456789
           </div>
         </div>
@@ -148,58 +150,58 @@ const colourGroups: { title: string; swatches: Swatch[] }[] = [
 
     {/* Component Examples */}
     <section class="mt-16">
-      <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Component Examples</h2>
+      <h2 class="text-2xl font-bold text-brand-foreground">Component Examples</h2>
 
-      <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">Buttons</h3>
+      <h3 class="text-lg font-semibold text-brand-foreground mt-8 mb-4">Buttons</h3>
       <div class="flex flex-wrap gap-3">
-        <button class="px-6 py-3 text-sm font-semibold bg-brand-navy text-white rounded-lg">Primary</button>
-        <button class="px-6 py-3 text-sm font-semibold bg-brand-gold text-brand-navy rounded-lg">CTA / Gold</button>
-        <button class="px-6 py-3 text-sm font-semibold border border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 rounded-lg">Secondary</button>
-        <button class="px-6 py-3 text-sm font-semibold bg-brand-green text-white rounded-lg">Success</button>
+        <button class="px-6 py-3 text-sm font-semibold bg-brand-primary text-brand-foreground rounded-lg">Primary</button>
+        <button class="px-6 py-3 text-sm font-semibold bg-brand-accent text-brand-primary rounded-lg">CTA / Gold</button>
+        <button class="px-6 py-3 text-sm font-semibold border border-white/10 text-brand-foreground rounded-lg">Secondary</button>
+        <button class="px-6 py-3 text-sm font-semibold bg-brand-highlight text-white rounded-lg">Success</button>
       </div>
 
-      <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">Cards</h3>
+      <h3 class="text-lg font-semibold text-brand-foreground mt-8 mb-4">Cards</h3>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-6">
-          <h4 class="font-semibold text-brand-navy dark:text-white">Light Card</h4>
-          <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">Standard card on white background with subtle border.</p>
+        <div class="bg-white/5 border border-white/10 rounded-xl p-6">
+          <h4 class="font-semibold text-brand-foreground">Light Card</h4>
+          <p class="mt-1 text-sm text-brand-foreground-muted">Standard card on white background with subtle border.</p>
         </div>
-        <div class="bg-brand-navy text-white rounded-xl p-6">
+        <div class="bg-brand-primary text-brand-foreground rounded-xl p-6">
           <h4 class="font-semibold">Dark Card</h4>
-          <p class="mt-1 text-sm text-gray-300">Inverted card for hero sections and dark backgrounds.</p>
+          <p class="mt-1 text-sm text-brand-foreground">Inverted card for hero sections and dark backgrounds.</p>
         </div>
       </div>
 
-      <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">Hero Section (Dark)</h3>
-      <div class="bg-brand-navy rounded-xl p-8 text-white">
+      <h3 class="text-lg font-semibold text-brand-foreground mt-8 mb-4">Hero Section (Dark)</h3>
+      <div class="bg-brand-primary rounded-xl p-8 text-brand-foreground">
         <h4 class="text-2xl font-bold">
-          Heading on <span class="text-brand-gold">dark background</span>
+          Heading on <span class="text-brand-accent">dark background</span>
         </h4>
-        <p class="mt-2 text-gray-300 max-w-md">
+        <p class="mt-2 text-brand-foreground max-w-md">
           Body text on dark background uses gray-300 for comfortable reading contrast.
         </p>
         <div class="mt-4 flex gap-3">
-          <button class="px-5 py-2.5 text-sm font-semibold bg-brand-gold text-brand-navy rounded-lg">Primary CTA</button>
-          <button class="px-5 py-2.5 text-sm font-semibold border border-white/30 text-white rounded-lg">Secondary CTA</button>
+          <button class="px-5 py-2.5 text-sm font-semibold bg-brand-accent text-brand-primary rounded-lg">Primary CTA</button>
+          <button class="px-5 py-2.5 text-sm font-semibold border border-white/30 text-brand-foreground rounded-lg">Secondary CTA</button>
         </div>
       </div>
     </section>
 
     {/* How it works */}
-    <section class="mt-16 bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-800 rounded-xl p-6">
-      <h2 class="text-lg font-bold text-gray-900 dark:text-gray-100">How This Works</h2>
-      <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
+    <section class="mt-16 bg-white/5 border border-white/10 rounded-xl p-6">
+      <h2 class="text-lg font-bold text-brand-foreground">How This Works</h2>
+      <p class="text-sm text-brand-foreground-muted mt-1">
         Brand values are defined in CSS custom properties. To change a colour,
-        edit <code class="bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded text-xs">src/styles/globals.css</code>
+        edit <code class="bg-white/10 px-1.5 py-0.5 rounded text-xs">src/styles/globals.css</code>
         and rebuild.
       </p>
-      <ul class="mt-3 space-y-2 text-sm text-gray-700 dark:text-gray-300">
+      <ul class="mt-3 space-y-2 text-sm text-brand-foreground">
         <li>
           <strong>Source of truth:</strong>{" "}
-          <code class="bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded text-xs">src/styles/globals.css</code>
+          <code class="bg-white/10 px-1.5 py-0.5 rounded text-xs">src/styles/globals.css</code>
         </li>
         <li>
-          <strong>Consumed via:</strong> Tailwind classes (e.g. <code class="bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded text-xs">bg-brand-navy</code>, <code class="bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded text-xs">text-brand-gold</code>)
+          <strong>Consumed via:</strong> Tailwind classes (e.g. <code class="bg-white/10 px-1.5 py-0.5 rounded text-xs">bg-brand-primary</code>, <code class="bg-white/10 px-1.5 py-0.5 rounded text-xs">text-brand-accent</code>)
         </li>
         <li>
           <strong>Never:</strong> hardcode hex values in components

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -7,87 +7,89 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
   description="Get in touch with ICATS, Imperial College's algorithmic trading society. Reach out for sponsorship, collaboration, or general enquiries."
   canonical="/contact"
 >
-  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
-    <div class="max-w-2xl">
-      <h1 class="text-3xl sm:text-4xl font-bold text-brand-navy dark:text-white">
-        Contact Us
-      </h1>
-      <p class="mt-2 text-gray-600 dark:text-gray-400">
-        Get in touch with the ICATS committee. We&apos;d love to hear from you.
-      </p>
+  <div class="bg-brand-primary">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+      <div class="max-w-2xl">
+        <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
+          Contact Us
+        </h1>
+        <p class="mt-2 text-brand-foreground-muted">
+          Get in touch with the ICATS committee. We&apos;d love to hear from you.
+        </p>
 
-      <div class="mt-8 space-y-4">
-        <div class="flex items-center gap-3 text-gray-700 dark:text-gray-300">
-          <svg class="w-5 h-5 text-brand-gold" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-          </svg>
-          <a href="mailto:algo.trade@imperial.ac.uk" class="text-brand-gold hover:underline">
-            algo.trade@imperial.ac.uk
-          </a>
+        <div class="mt-8 space-y-4">
+          <div class="flex items-center gap-3 text-brand-foreground">
+            <svg class="w-5 h-5 text-brand-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+            </svg>
+            <a href="mailto:algo.trade@imperial.ac.uk" class="text-brand-accent hover:underline">
+              algo.trade@imperial.ac.uk
+            </a>
+          </div>
+          <div class="flex items-center gap-3 text-brand-foreground">
+            <svg class="w-5 h-5 text-brand-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            <span>Imperial College London, South Kensington Campus, London SW7 2AZ</span>
+          </div>
         </div>
-        <div class="flex items-center gap-3 text-gray-700 dark:text-gray-300">
-          <svg class="w-5 h-5 text-brand-gold" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
-          </svg>
-          <span>Imperial College London, South Kensington Campus, London SW7 2AZ</span>
-        </div>
-      </div>
 
-      <form class="mt-10 space-y-5">
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-5">
+        <form class="mt-10 space-y-5">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-5">
+            <div>
+              <label for="name" class="block text-sm font-medium text-brand-foreground mb-1">
+                Name
+              </label>
+              <input
+                id="name"
+                type="text"
+                class="w-full px-4 py-2.5 border border-white/10 rounded-lg bg-white/5 text-brand-foreground focus:outline-none focus:ring-2 focus:ring-brand-accent focus:border-transparent"
+                placeholder="Your name"
+              />
+            </div>
+            <div>
+              <label for="email" class="block text-sm font-medium text-brand-foreground mb-1">
+                Email
+              </label>
+              <input
+                id="email"
+                type="email"
+                class="w-full px-4 py-2.5 border border-white/10 rounded-lg bg-white/5 text-brand-foreground focus:outline-none focus:ring-2 focus:ring-brand-accent focus:border-transparent"
+                placeholder="your.name@imperial.ac.uk"
+              />
+            </div>
+          </div>
           <div>
-            <label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Name
+            <label for="subject" class="block text-sm font-medium text-brand-foreground mb-1">
+              Subject
             </label>
             <input
-              id="name"
+              id="subject"
               type="text"
-              class="w-full px-4 py-2.5 border border-gray-300 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-gold focus:border-transparent"
-              placeholder="Your name"
+              class="w-full px-4 py-2.5 border border-white/10 rounded-lg bg-white/5 text-brand-foreground focus:outline-none focus:ring-2 focus:ring-brand-accent focus:border-transparent"
+              placeholder="What&apos;s this about?"
             />
           </div>
           <div>
-            <label for="email" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Email
+            <label for="message" class="block text-sm font-medium text-brand-foreground mb-1">
+              Message
             </label>
-            <input
-              id="email"
-              type="email"
-              class="w-full px-4 py-2.5 border border-gray-300 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-gold focus:border-transparent"
-              placeholder="your.name@imperial.ac.uk"
-            />
+            <textarea
+              id="message"
+              rows="5"
+              class="w-full px-4 py-2.5 border border-white/10 rounded-lg bg-white/5 text-brand-foreground focus:outline-none focus:ring-2 focus:ring-brand-accent focus:border-transparent resize-none"
+              placeholder="Your message..."
+            ></textarea>
           </div>
-        </div>
-        <div>
-          <label for="subject" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-            Subject
-          </label>
-          <input
-            id="subject"
-            type="text"
-            class="w-full px-4 py-2.5 border border-gray-300 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-gold focus:border-transparent"
-            placeholder="What&apos;s this about?"
-          />
-        </div>
-        <div>
-          <label for="message" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-            Message
-          </label>
-          <textarea
-            id="message"
-            rows="5"
-            class="w-full px-4 py-2.5 border border-gray-300 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-gold focus:border-transparent resize-none"
-            placeholder="Your message..."
-          ></textarea>
-        </div>
-        <button
-          type="submit"
-          class="px-6 py-3 text-sm font-semibold bg-brand-navy text-white rounded-lg hover:bg-brand-dark transition-colors"
-        >
-          Send Message
-        </button>
-      </form>
+          <button
+            type="submit"
+            class="px-6 py-3 text-sm font-semibold bg-brand-accent text-brand-primary rounded-lg hover:bg-amber-400 transition-colors"
+          >
+            Send Message
+          </button>
+        </form>
+      </div>
     </div>
   </div>
 </BaseLayout>

--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -48,18 +48,19 @@ const eventsJsonLd = events.map((e) => ({
   description="Upcoming ICATS events at Imperial College: competitions, workshops, quant sessions, company presentations, and socials throughout the academic year."
   canonical="/events"
 >
-  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+  <div class="bg-brand-primary">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
     {eventsJsonLd.length > 0 && (
       <script type="application/ld+json" set:html={JSON.stringify(eventsJsonLd)} />
     )}
 
-    <h1 class="text-3xl sm:text-4xl font-bold text-brand-navy dark:text-white">Events</h1>
-    <p class="mt-2 text-gray-600 dark:text-gray-400 max-w-xl">
+    <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">Events</h1>
+    <p class="mt-2 text-brand-foreground-muted max-w-xl">
       Competitions, workshops, lectures, and socials throughout the academic year.
     </p>
 
     {events.length === 0 ? (
-      <p class="mt-10 text-gray-500 dark:text-gray-400">No upcoming events. Check back soon.</p>
+      <p class="mt-10 text-brand-foreground-muted">No upcoming events. Check back soon.</p>
     ) : (
       <div class="mt-10 grid grid-cols-1 lg:grid-cols-2 gap-6">
         {events.map((e) => {
@@ -67,21 +68,21 @@ const eventsJsonLd = events.map((e) => ({
           const category = e.category || "";
 
           return (
-            <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-6 hover:shadow-md transition-shadow">
+            <div class="bg-white/5 border border-white/10 rounded-xl p-6 hover:shadow-md transition-shadow">
               <div class="flex-1">
                 <span
                   class={`inline-block px-2.5 py-0.5 text-xs font-medium rounded-full ${
-                    eventCategoryColours[category] || "bg-gray-100 text-gray-700"
+                    eventCategoryColours[category] || "bg-white/10 text-brand-foreground"
                   }`}
                 >
                   {eventCategoryLabels[category] || category}
                 </span>
-                <h3 class="mt-2 text-lg font-semibold text-brand-navy dark:text-white">{e.title}</h3>
+                <h3 class="mt-2 text-lg font-semibold text-brand-foreground">{e.title}</h3>
                 {e.body && (
-                  <div class="mt-1 text-sm text-gray-600 dark:text-gray-400 prose prose-sm dark:prose-invert max-w-none" set:html={toHTML(e.body)} />
+                  <div class="mt-1 text-sm text-brand-foreground-muted prose prose-sm max-w-none" set:html={toHTML(e.body)} />
                 )}
               </div>
-              <div class="mt-4 flex flex-wrap gap-4 text-sm text-gray-500 dark:text-gray-400">
+              <div class="mt-4 flex flex-wrap gap-4 text-sm text-brand-foreground-muted">
                 <span class="flex items-center gap-1.5">
                   <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
@@ -108,7 +109,7 @@ const eventsJsonLd = events.map((e) => ({
                     href={e.rsvpUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="inline-block px-4 py-2 text-sm font-medium bg-brand-navy text-white rounded-lg hover:bg-brand-dark transition-colors"
+                    class="inline-block px-4 py-2 text-sm font-medium bg-brand-accent text-brand-primary rounded-lg hover:bg-amber-400 transition-colors"
                   >
                     RSVP
                   </a>
@@ -119,5 +120,6 @@ const eventsJsonLd = events.map((e) => ({
         })}
       </div>
     )}
+    </div>
   </div>
 </BaseLayout>

--- a/src/pages/fantasy-league.astro
+++ b/src/pages/fantasy-league.astro
@@ -36,13 +36,13 @@ const features = [
 >
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
     <div class="max-w-3xl">
-      <span class="inline-block px-3 py-1 text-xs font-bold bg-brand-gold/20 text-brand-gold rounded-full uppercase tracking-wider mb-4">
+      <span class="inline-block px-3 py-1 text-xs font-bold bg-brand-accent/20 text-brand-accent rounded-full uppercase tracking-wider mb-4">
         Coming October 2026
       </span>
-      <h1 class="text-3xl sm:text-4xl font-bold text-brand-navy dark:text-white">
+      <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
         Portfolio Fantasy League
       </h1>
-      <p class="mt-4 text-lg text-gray-600 dark:text-gray-400 leading-relaxed">
+      <p class="mt-4 text-lg text-brand-foreground-muted leading-relaxed">
         Build a virtual portfolio, compete against 2,000+ Imperial students,
         and climb the leaderboard. No real money, real learning.
       </p>
@@ -50,16 +50,16 @@ const features = [
 
     <div class="mt-12 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
       {features.map((f) => (
-        <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-6">
-          <h3 class="font-semibold text-brand-navy dark:text-white">{f.title}</h3>
-          <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">{f.desc}</p>
+        <div class="bg-white/5 border border-white/10 rounded-xl p-6">
+          <h3 class="font-semibold text-brand-foreground">{f.title}</h3>
+          <p class="mt-2 text-sm text-brand-foreground-muted">{f.desc}</p>
         </div>
       ))}
     </div>
 
-    <div class="mt-12 bg-brand-navy rounded-xl p-8 text-center text-white">
+    <div class="mt-12 bg-brand-primary rounded-xl p-8 text-center text-brand-foreground">
       <h2 class="text-xl font-bold">Launching First Week of October</h2>
-      <p class="mt-2 text-gray-400 max-w-md mx-auto">
+      <p class="mt-2 text-brand-foreground-muted max-w-md mx-auto">
         The Fantasy League will open for registration during Freshers Week.
         Sign up to the newsletter to get notified.
       </p>
@@ -67,16 +67,16 @@ const features = [
         <input
           type="email"
           placeholder="your.name@imperial.ac.uk"
-          class="flex-1 px-4 py-3 rounded-lg bg-white/10 border border-white/20 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-gold"
+          class="flex-1 px-4 py-3 rounded-lg bg-white/10 border border-white/20 text-brand-foreground placeholder-brand-foreground-muted focus:outline-none focus:ring-2 focus:ring-brand-accent"
         />
-        <button class="px-6 py-3 bg-brand-gold text-brand-navy font-semibold rounded-lg hover:bg-amber-400 transition-colors">
+        <button class="px-6 py-3 bg-brand-accent text-brand-primary font-semibold rounded-lg hover:bg-amber-400 transition-colors">
           Notify Me
         </button>
       </div>
     </div>
 
     <div class="mt-8">
-      <a href="/" class="text-sm text-brand-gold hover:underline">
+      <a href="/" class="text-sm text-brand-accent hover:underline">
         &larr; Back to home
       </a>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -85,20 +85,21 @@ const organizationJsonLd = {
 ---
 
 <BaseLayout canonical="https://algosoc.com/">
+  <div class="bg-brand-primary">
   <script type="application/ld+json" set:html={JSON.stringify(organizationJsonLd)} />
 
   <!-- Hero -->
   <section
-    class="text-white noise-overlay relative"
-    style="background: linear-gradient(135deg, var(--color-brand-navy) 0%, var(--color-brand-dark-slate) 50%, var(--color-brand-navy) 100%)"
+    class="text-brand-foreground noise-overlay relative"
+    style="background: linear-gradient(135deg, var(--color-brand-primary) 0%, var(--color-brand-slate) 50%, var(--color-brand-primary) 100%)"
   >
     <div class="relative z-10 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-20 sm:py-28">
       <div class="max-w-3xl">
         <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold tracking-tight leading-tight">
           Imperial College&apos;s Premier Society for{" "}
-          <span class="text-brand-gold">Aspiring Traders</span>
+          <span class="text-brand-accent">Aspiring Traders</span>
         </h1>
-        <p class="mt-6 text-lg text-gray-300 leading-relaxed max-w-2xl">
+        <p class="mt-6 text-lg text-brand-foreground leading-relaxed max-w-2xl">
           Building the next generation of quantitative traders, researchers,
           and technologists through education, competitions, and real-world
           experience.
@@ -106,13 +107,13 @@ const organizationJsonLd = {
         <div class="mt-8 flex flex-wrap gap-4">
           <a
             href="/join"
-            class="px-6 py-3 text-sm font-semibold bg-brand-gold text-brand-navy rounded-lg hover:bg-amber-400 transition-colors btn-glow"
+            class="px-6 py-3 text-sm font-semibold bg-brand-accent text-brand-primary rounded-lg hover:bg-amber-400 transition-colors btn-glow"
           >
             Join ICATS
           </a>
           <a
             href="/programmes"
-            class="px-6 py-3 text-sm font-semibold border border-white/30 text-white rounded-lg hover:bg-white/10 transition-colors"
+            class="px-6 py-3 text-sm font-semibold border border-white/30 text-brand-foreground rounded-lg hover:bg-white/10 transition-colors"
           >
             Explore Programmes
           </a>
@@ -127,8 +128,8 @@ const organizationJsonLd = {
           { value: stats.partners, label: "Industry Partners" },
         ].map((s) => (
           <div class="text-center">
-            <div class="text-3xl sm:text-4xl font-bold text-brand-gold">{s.value}</div>
-            <div class="text-sm text-gray-400 mt-1">{s.label}</div>
+            <div class="text-3xl sm:text-4xl font-bold text-brand-accent">{s.value}</div>
+            <div class="text-sm text-brand-foreground-muted mt-1">{s.label}</div>
           </div>
         ))}
       </div>
@@ -140,10 +141,10 @@ const organizationJsonLd = {
   <FadeIn>
     <section class="py-16 sm:py-20">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <h2 class="text-2xl sm:text-3xl font-bold text-brand-navy dark:text-white">
+        <h2 class="text-2xl sm:text-3xl font-bold text-brand-foreground">
           Our Programmes
         </h2>
-        <p class="mt-2 text-gray-600 dark:text-gray-400 max-w-xl">
+        <p class="mt-2 text-brand-foreground-muted max-w-xl">
           From introductory courses to competitive trading, we offer something
           for every level of experience.
         </p>
@@ -152,15 +153,15 @@ const organizationJsonLd = {
             {allProgrammes.map((p) => (
               <a
                 href={`/programmes/${p.slug.current}`}
-                class="group block bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-6 hover:shadow-lg hover:border-brand-gold/30 transition-all"
+                class="group block bg-white/5 border border-white/10 rounded-xl p-6 hover:shadow-lg hover:border-brand-accent/30 transition-all"
               >
-                <h3 class="text-lg font-semibold text-brand-navy dark:text-white group-hover:text-brand-gold transition-colors">
+                <h3 class="text-lg font-semibold text-brand-foreground group-hover:text-brand-accent transition-colors">
                   {p.title}
                 </h3>
                 {p.description && (
-                  <p class="mt-2 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">{p.description}</p>
+                  <p class="mt-2 text-sm text-brand-foreground-muted leading-relaxed">{p.description}</p>
                 )}
-                <span class="inline-block mt-4 text-sm font-medium text-brand-gold">
+                <span class="inline-block mt-4 text-sm font-medium text-brand-accent">
                   Learn more &rarr;
                 </span>
               </a>
@@ -173,35 +174,35 @@ const organizationJsonLd = {
 
   <!-- Events Preview -->
   <FadeIn>
-    <section class="py-16 sm:py-20 bg-brand-light dark:bg-gray-900/50">
+    <section class="py-16 sm:py-20 bg-white/5">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div class="flex items-end justify-between mb-8">
           <div>
-            <h2 class="text-2xl sm:text-3xl font-bold text-brand-navy dark:text-white">
+            <h2 class="text-2xl sm:text-3xl font-bold text-brand-foreground">
               Upcoming Events
             </h2>
-            <p class="mt-2 text-gray-600 dark:text-gray-400">
+            <p class="mt-2 text-brand-foreground-muted">
               What&apos;s coming up this term.
             </p>
           </div>
-          <a href="/events" class="text-sm font-medium text-brand-gold hover:underline">
+          <a href="/events" class="text-sm font-medium text-brand-accent hover:underline">
             View all &rarr;
           </a>
         </div>
-        <div class="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 p-6">
+        <div class="bg-white/5 rounded-xl border border-white/10 p-6">
           {upcomingEvents.map((e) => {
             const d = new Date(e.date);
             const month = d.toLocaleString("en-GB", { month: "short" }).toUpperCase();
             const day = d.getDate();
             return (
-              <div class="flex items-center gap-4 py-3 border-b border-gray-100 dark:border-gray-800 last:border-0">
+              <div class="flex items-center gap-4 py-3 border-b border-white/10 last:border-0">
                 <div class="flex-shrink-0 w-14 text-center">
-                  <div class="text-xs font-medium text-brand-gold">{month}</div>
-                  <div class="text-xl font-bold text-brand-navy dark:text-white">{day}</div>
+                  <div class="text-xs font-medium text-brand-accent">{month}</div>
+                  <div class="text-xl font-bold text-brand-foreground">{day}</div>
                 </div>
                 <div class="flex-1 min-w-0">
-                  <div class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{e.title}</div>
-                  <span class="inline-block mt-0.5 px-2 py-0.5 text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 rounded-full">
+                  <div class="text-sm font-medium text-brand-foreground truncate">{e.title}</div>
+                  <span class="inline-block mt-0.5 px-2 py-0.5 text-xs font-medium bg-white/10 text-brand-foreground-muted rounded-full">
                     {e.category}
                   </span>
                 </div>
@@ -217,10 +218,10 @@ const organizationJsonLd = {
   <FadeIn>
     <section class="py-16 sm:py-20">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-center">
-        <h2 class="text-2xl sm:text-3xl font-bold text-brand-navy dark:text-white">
+        <h2 class="text-2xl sm:text-3xl font-bold text-brand-foreground">
           Our Partners
         </h2>
-        <p class="mt-2 text-gray-600 dark:text-gray-400 max-w-xl mx-auto">
+        <p class="mt-2 text-brand-foreground-muted max-w-xl mx-auto">
           Supported by leading firms in quantitative finance and trading.
         </p>
         <div class="mt-10 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-6 max-w-5xl mx-auto">
@@ -229,7 +230,7 @@ const organizationJsonLd = {
           ))}
         </div>
         <div class="mt-8">
-          <a href="/sponsors" class="text-sm font-medium text-brand-gold hover:underline">
+          <a href="/sponsors" class="text-sm font-medium text-brand-accent hover:underline">
             View all sponsors &rarr;
           </a>
         </div>
@@ -239,12 +240,12 @@ const organizationJsonLd = {
 
   <!-- Newsletter CTA -->
   <section
-    class="py-16 sm:py-20 text-white noise-overlay relative"
-    style="background: linear-gradient(135deg, var(--color-brand-navy) 0%, var(--color-brand-dark-slate) 50%, var(--color-brand-navy) 100%)"
+    class="py-16 sm:py-20 text-brand-foreground noise-overlay relative"
+    style="background: linear-gradient(135deg, var(--color-brand-primary) 0%, var(--color-brand-slate) 50%, var(--color-brand-primary) 100%)"
   >
     <div class="relative z-10 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-center">
       <h2 class="text-2xl sm:text-3xl font-bold">Stay in the Loop</h2>
-      <p class="mt-2 text-gray-400 max-w-md mx-auto">
+      <p class="mt-2 text-brand-foreground-muted max-w-md mx-auto">
         Get weekly market recaps, event updates, and quant insights straight
         to your inbox.
       </p>
@@ -252,15 +253,16 @@ const organizationJsonLd = {
         <input
           type="email"
           placeholder="your.name@imperial.ac.uk"
-          class="flex-1 px-4 py-3 rounded-lg bg-white/10 border border-white/20 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-gold"
+          class="flex-1 px-4 py-3 rounded-lg bg-white/10 border border-white/20 text-brand-foreground placeholder-brand-foreground-muted focus:outline-none focus:ring-2 focus:ring-brand-accent"
         />
         <button
           type="submit"
-          class="px-6 py-3 bg-brand-gold text-brand-navy font-semibold rounded-lg hover:bg-amber-400 transition-colors"
+          class="px-6 py-3 bg-brand-accent text-brand-primary font-semibold rounded-lg hover:bg-amber-400 transition-colors"
         >
           Subscribe
         </button>
       </form>
     </div>
   </section>
+  </div>
 </BaseLayout>

--- a/src/pages/join.astro
+++ b/src/pages/join.astro
@@ -22,45 +22,47 @@ const columns = [
   description="Join ICATS and become part of Imperial College's algorithmic trading community. Access competitions, courses, networking, and career opportunities in quant finance."
   canonical="/join"
 >
-  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
-    <div class="max-w-2xl mx-auto text-center">
-      <h1 class="text-3xl sm:text-4xl font-bold text-brand-navy dark:text-white">
-        Join ICATS
-      </h1>
-      <p class="mt-4 text-lg text-gray-600 dark:text-gray-400 leading-relaxed">
-        Become part of Imperial College&apos;s largest algorithmic trading and
-        quantitative finance community. Membership gives you access to all our
-        programmes, events, and resources.
-      </p>
-
-      <div class="mt-10 grid grid-cols-1 sm:grid-cols-3 gap-4 text-left">
-        {columns.map((col) => (
-          <div class="bg-brand-light dark:bg-gray-900/50 rounded-xl p-6">
-            <h3 class="font-bold text-brand-navy dark:text-white">{col.title}</h3>
-            <ul class="mt-3 space-y-2">
-              {col.items.map((item) => (
-                <li class="text-sm text-gray-600 dark:text-gray-400 flex items-start gap-2">
-                  <svg class="w-4 h-4 text-brand-gold mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                    <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
-                  </svg>
-                  {item}
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))}
-      </div>
-
-      <div class="mt-10">
-        <a
-          href="#"
-          class="inline-block px-8 py-4 text-base font-semibold bg-brand-gold text-brand-navy rounded-lg hover:bg-amber-400 transition-colors"
-        >
-          Join via Imperial College Union
-        </a>
-        <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">
-          Free for all Imperial College students.
+  <div class="bg-brand-primary">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+      <div class="max-w-2xl mx-auto text-center">
+        <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
+          Join ICATS
+        </h1>
+        <p class="mt-4 text-lg text-brand-foreground-muted leading-relaxed">
+          Become part of Imperial College&apos;s largest algorithmic trading and
+          quantitative finance community. Membership gives you access to all our
+          programmes, events, and resources.
         </p>
+
+        <div class="mt-10 grid grid-cols-1 sm:grid-cols-3 gap-4 text-left">
+          {columns.map((col) => (
+            <div class="bg-white/5 rounded-xl p-6">
+              <h3 class="font-bold text-brand-foreground">{col.title}</h3>
+              <ul class="mt-3 space-y-2">
+                {col.items.map((item) => (
+                  <li class="text-sm text-brand-foreground-muted flex items-start gap-2">
+                    <svg class="w-4 h-4 text-brand-accent mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                      <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+                    </svg>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        <div class="mt-10">
+          <a
+            href="#"
+            class="inline-block px-8 py-4 text-base font-semibold bg-brand-accent text-brand-primary rounded-lg hover:bg-amber-400 transition-colors"
+          >
+            Join via Imperial College Union
+          </a>
+          <p class="mt-3 text-sm text-brand-foreground-muted">
+            Free for all Imperial College students.
+          </p>
+        </div>
       </div>
     </div>
   </div>

--- a/src/pages/leaderboard.astro
+++ b/src/pages/leaderboard.astro
@@ -22,76 +22,78 @@ const categories = ["Overall", "Events", "Competitions", "Fantasy League"];
   description="ICATS member leaderboard: track rankings across competitions, courses, and society engagement."
   canonical="/leaderboard"
 >
-  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
-    <h1 class="text-3xl sm:text-4xl font-bold text-brand-navy dark:text-white">
-      Leaderboard
-    </h1>
-    <p class="mt-2 text-gray-600 dark:text-gray-400 max-w-xl">
-      ICATS engagement leaderboard. Earn points by attending events, competing,
-      and contributing.
-    </p>
+  <div class="bg-brand-primary">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+      <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
+        Leaderboard
+      </h1>
+      <p class="mt-2 text-brand-foreground-muted max-w-xl">
+        ICATS engagement leaderboard. Earn points by attending events, competing,
+        and contributing.
+      </p>
 
-    <div class="mt-4 flex gap-2">
-      {categories.map((cat) => (
-        <button
-          class={`px-3 py-1.5 text-xs font-medium rounded-full transition-colors ${
-            cat === "Overall"
-              ? "bg-brand-navy text-white"
-              : "bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
-          }`}
-        >
-          {cat}
-        </button>
-      ))}
-    </div>
+      <div class="mt-4 flex gap-2">
+        {categories.map((cat) => (
+          <button
+            class={`px-3 py-1.5 text-xs font-medium rounded-full transition-colors ${
+              cat === "Overall"
+                ? "bg-brand-accent text-brand-primary"
+                : "bg-white/10 text-brand-foreground-muted hover:bg-white/20"
+            }`}
+          >
+            {cat}
+          </button>
+        ))}
+      </div>
 
-    <div class="mt-8 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl overflow-hidden">
-      <table class="w-full">
-        <thead>
-          <tr class="border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-800/50">
-            <th class="text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider px-6 py-3 w-16">
-              Rank
-            </th>
-            <th class="text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider px-6 py-3">
-              Member
-            </th>
-            <th class="text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider px-6 py-3">
-              Points
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {mockLeaderboard.map((entry) => (
-            <tr class="border-b border-gray-100 dark:border-gray-800 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
-              <td class="px-6 py-4">
-                <span
-                  class={`inline-flex items-center justify-center w-8 h-8 rounded-full text-sm font-bold ${
-                    entry.rank === 1
-                      ? "bg-amber-100 text-amber-700"
-                      : entry.rank === 2
-                        ? "bg-gray-100 text-gray-600"
-                        : entry.rank === 3
-                          ? "bg-orange-100 text-orange-700"
-                          : "text-gray-500"
-                  }`}
-                >
-                  {entry.rank}
-                </span>
-              </td>
-              <td class="px-6 py-4 font-medium text-brand-navy dark:text-white">
-                {entry.name}
-              </td>
-              <td class="px-6 py-4 text-right font-semibold text-brand-gold">
-                {entry.points.toLocaleString()}
-              </td>
+      <div class="mt-8 bg-white/5 border border-white/10 rounded-xl overflow-hidden">
+        <table class="w-full">
+          <thead>
+            <tr class="border-b border-white/10 bg-white/5">
+              <th class="text-left text-xs font-medium text-brand-foreground-muted uppercase tracking-wider px-6 py-3 w-16">
+                Rank
+              </th>
+              <th class="text-left text-xs font-medium text-brand-foreground-muted uppercase tracking-wider px-6 py-3">
+                Member
+              </th>
+              <th class="text-right text-xs font-medium text-brand-foreground-muted uppercase tracking-wider px-6 py-3">
+                Points
+              </th>
             </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+          </thead>
+          <tbody>
+            {mockLeaderboard.map((entry) => (
+              <tr class="border-b border-white/10 last:border-0 hover:bg-white/5 transition-colors">
+                <td class="px-6 py-4">
+                  <span
+                    class={`inline-flex items-center justify-center w-8 h-8 rounded-full text-sm font-bold ${
+                      entry.rank === 1
+                        ? "bg-amber-500/20 text-amber-400"
+                        : entry.rank === 2
+                          ? "bg-white/10 text-brand-foreground-muted"
+                          : entry.rank === 3
+                            ? "bg-orange-500/20 text-orange-400"
+                            : "text-brand-foreground-muted"
+                    }`}
+                  >
+                    {entry.rank}
+                  </span>
+                </td>
+                <td class="px-6 py-4 font-medium text-brand-foreground">
+                  {entry.name}
+                </td>
+                <td class="px-6 py-4 text-right font-semibold text-brand-accent">
+                  {entry.points.toLocaleString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
 
-    <p class="mt-4 text-xs text-gray-500 dark:text-gray-400 text-center">
-      Demo data. Live leaderboard will be available when the points system launches.
-    </p>
+      <p class="mt-4 text-xs text-brand-foreground-muted text-center">
+        Demo data. Live leaderboard will be available when the points system launches.
+      </p>
+    </div>
   </div>
 </BaseLayout>

--- a/src/pages/programmes/algothon.astro
+++ b/src/pages/programmes/algothon.astro
@@ -45,147 +45,149 @@ const editions = await client.fetch<AlgothonEdition[]>(
   description="Algothon is ICATS' flagship annual inter-university algorithmic trading hackathon. Teams build and submit trading strategies, competing for prizes from top firms."
   canonical="/programmes/algothon"
 >
-  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
-    <a
-      href="/programmes"
-      class="text-sm font-medium text-brand-gold hover:underline"
-    >
-      &larr; All programmes
-    </a>
+  <div class="bg-brand-primary">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+      <a
+        href="/programmes"
+        class="text-sm font-medium text-brand-accent hover:underline"
+      >
+        &larr; All programmes
+      </a>
 
-    <h1 class="mt-4 text-3xl sm:text-4xl font-bold text-brand-navy dark:text-white">
-      Algothon
-    </h1>
-    <p class="mt-2 text-gray-600 dark:text-gray-400 max-w-2xl">
-      Our flagship annual London inter-university hackathon where students
-      compete in algorithmic trading challenges. Teams build and submit trading
-      strategies against a live or historical dataset, judged on risk-adjusted
-      returns.
-    </p>
-
-    {editions.length === 0 ? (
-      <p class="mt-10 text-gray-500 dark:text-gray-400">
-        Details for upcoming Algothon editions will be announced soon.
+      <h1 class="mt-4 text-3xl sm:text-4xl font-bold text-brand-foreground">
+        Algothon
+      </h1>
+      <p class="mt-2 text-brand-foreground-muted max-w-2xl">
+        Our flagship annual London inter-university hackathon where students
+        compete in algorithmic trading challenges. Teams build and submit trading
+        strategies against a live or historical dataset, judged on risk-adjusted
+        returns.
       </p>
-    ) : (
-      <div class="mt-12 space-y-16">
-        {editions.map((edition) => {
-          const sponsorCount = edition.sponsors?.length ?? 0;
-          const recapHtml = edition.recap ? toHTML(edition.recap) : "";
 
-          return (
-            <section
-              id={edition.slug.current}
-              class="scroll-mt-24"
-            >
-              {/* Header + stats */}
-              <div class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
-                <h2 class="text-2xl font-bold text-brand-navy dark:text-white">
-                  {edition.title}
-                </h2>
-                <div class="flex gap-6">
-                  {edition.participants != null && (
-                    <div class="text-center">
-                      <div class="text-2xl font-bold text-brand-gold">{edition.participants}</div>
-                      <div class="text-xs text-gray-500 dark:text-gray-400">Participants</div>
-                    </div>
-                  )}
-                  {sponsorCount > 0 && (
-                    <div class="text-center">
-                      <div class="text-2xl font-bold text-brand-gold">{sponsorCount}</div>
-                      <div class="text-xs text-gray-500 dark:text-gray-400">Sponsors</div>
-                    </div>
-                  )}
-                </div>
-              </div>
+      {editions.length === 0 ? (
+        <p class="mt-10 text-brand-foreground-muted">
+          Details for upcoming Algothon editions will be announced soon.
+        </p>
+      ) : (
+        <div class="mt-12 space-y-16">
+          {editions.map((edition) => {
+            const sponsorCount = edition.sponsors?.length ?? 0;
+            const recapHtml = edition.recap ? toHTML(edition.recap) : "";
 
-              {/* Image carousel */}
-              {edition.images && edition.images.length > 0 && (
-                <div
-                  class="algothon-carousel mt-6 relative overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-900"
-                  data-carousel
-                >
-                  <div class="carousel-track flex transition-transform duration-500 ease-in-out">
-                    {edition.images.map((img) => (
-                      <div class="carousel-slide w-full flex-shrink-0">
-                        <img
-                          src={img.asset?.url}
-                          alt={img.alt || edition.title}
-                          loading="lazy"
-                          class="w-full h-auto object-contain"
-                        />
-                        {img.caption && (
-                          <p class="absolute bottom-0 inset-x-0 bg-black/50 text-white text-sm px-4 py-2">
-                            {img.caption}
-                          </p>
-                        )}
+            return (
+              <section
+                id={edition.slug.current}
+                class="scroll-mt-24"
+              >
+                {/* Header + stats */}
+                <div class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+                  <h2 class="text-2xl font-bold text-brand-foreground">
+                    {edition.title}
+                  </h2>
+                  <div class="flex gap-6">
+                    {edition.participants != null && (
+                      <div class="text-center">
+                        <div class="text-2xl font-bold text-brand-accent">{edition.participants}</div>
+                        <div class="text-xs text-brand-foreground-muted">Participants</div>
                       </div>
-                    ))}
+                    )}
+                    {sponsorCount > 0 && (
+                      <div class="text-center">
+                        <div class="text-2xl font-bold text-brand-accent">{sponsorCount}</div>
+                        <div class="text-xs text-brand-foreground-muted">Sponsors</div>
+                      </div>
+                    )}
                   </div>
+                </div>
 
-                  {edition.images.length > 1 && (
-                    <>
-                      <button
-                        type="button"
-                        class="carousel-prev absolute left-2 top-1/2 -translate-y-1/2 bg-black/40 hover:bg-black/60 text-white rounded-full w-10 h-10 flex items-center justify-center transition-colors"
-                        aria-label="Previous image"
-                      >
-                        &#8249;
-                      </button>
-                      <button
-                        type="button"
-                        class="carousel-next absolute right-2 top-1/2 -translate-y-1/2 bg-black/40 hover:bg-black/60 text-white rounded-full w-10 h-10 flex items-center justify-center transition-colors"
-                        aria-label="Next image"
-                      >
-                        &#8250;
-                      </button>
-                      <div class="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-2">
-                        {edition.images.map((_, i) => (
-                          <button
-                            type="button"
-                            class={`carousel-dot w-2.5 h-2.5 rounded-full transition-colors ${i === 0 ? "bg-white" : "bg-white/50"}`}
-                            data-index={i}
-                            aria-label={`Go to image ${i + 1}`}
+                {/* Image carousel */}
+                {edition.images && edition.images.length > 0 && (
+                  <div
+                    class="algothon-carousel mt-6 relative overflow-hidden rounded-xl bg-black/20"
+                    data-carousel
+                  >
+                    <div class="carousel-track flex transition-transform duration-500 ease-in-out">
+                      {edition.images.map((img) => (
+                        <div class="carousel-slide w-full flex-shrink-0">
+                          <img
+                            src={img.asset?.url}
+                            alt={img.alt || edition.title}
+                            loading="lazy"
+                            class="w-full h-auto object-contain"
                           />
-                        ))}
-                      </div>
-                    </>
-                  )}
-                </div>
-              )}
+                          {img.caption && (
+                            <p class="absolute bottom-0 inset-x-0 bg-black/50 text-brand-foreground text-sm px-4 py-2">
+                              {img.caption}
+                            </p>
+                          )}
+                        </div>
+                      ))}
+                    </div>
 
-              {/* Recap */}
-              {recapHtml && (
-                <div
-                  class="mt-6 prose prose-gray dark:prose-invert max-w-none"
-                  set:html={recapHtml}
-                />
-              )}
-
-              {/* Sponsors */}
-              {edition.sponsors && edition.sponsors.length > 0 && (
-                <div class="mt-8">
-                  <h3 class="text-lg font-semibold text-brand-navy dark:text-white mb-4">
-                    Sponsors
-                  </h3>
-                  <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-                    {edition.sponsors.map((s) => (
-                      <SponsorLogo
-                        name={s.name}
-                        logo={s.logo?.asset?.url || ""}
-                        description={s.description}
-                        websiteUrl={s.websiteUrl}
-                        variant="dark"
-                      />
-                    ))}
+                    {edition.images.length > 1 && (
+                      <>
+                        <button
+                          type="button"
+                          class="carousel-prev absolute left-2 top-1/2 -translate-y-1/2 bg-black/40 hover:bg-black/60 text-brand-foreground rounded-full w-10 h-10 flex items-center justify-center transition-colors"
+                          aria-label="Previous image"
+                        >
+                          &#8249;
+                        </button>
+                        <button
+                          type="button"
+                          class="carousel-next absolute right-2 top-1/2 -translate-y-1/2 bg-black/40 hover:bg-black/60 text-brand-foreground rounded-full w-10 h-10 flex items-center justify-center transition-colors"
+                          aria-label="Next image"
+                        >
+                          &#8250;
+                        </button>
+                        <div class="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-2">
+                          {edition.images.map((_, i) => (
+                            <button
+                              type="button"
+                              class={`carousel-dot w-2.5 h-2.5 rounded-full transition-colors ${i === 0 ? "bg-white" : "bg-white/50"}`}
+                              data-index={i}
+                              aria-label={`Go to image ${i + 1}`}
+                            />
+                          ))}
+                        </div>
+                      </>
+                    )}
                   </div>
-                </div>
-              )}
-            </section>
-          );
-        })}
-      </div>
-    )}
+                )}
+
+                {/* Recap */}
+                {recapHtml && (
+                  <div
+                    class="mt-6 prose prose-invert prose-lg max-w-none prose-li:text-brand-foreground prose-p:text-brand-foreground"
+                    set:html={recapHtml}
+                  />
+                )}
+
+                {/* Sponsors */}
+                {edition.sponsors && edition.sponsors.length > 0 && (
+                  <div class="mt-8">
+                    <h3 class="text-lg font-semibold text-brand-foreground mb-4">
+                      Sponsors
+                    </h3>
+                    <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+                      {edition.sponsors.map((s) => (
+                        <SponsorLogo
+                          name={s.name}
+                          logo={s.logo?.asset?.url || ""}
+                          description={s.description}
+                          websiteUrl={s.websiteUrl}
+                          variant="light"
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </section>
+            );
+          })}
+        </div>
+      )}
+    </div>
   </div>
 </BaseLayout>
 

--- a/src/pages/programmes/index.astro
+++ b/src/pages/programmes/index.astro
@@ -17,28 +17,29 @@ const programmes = await client.fetch<Array<{
   description="ICATS programmes: Algothon, AlgoCourse, Queen's Tower Capital, and more. Education and hands-on experience in algorithmic trading and quantitative finance."
   canonical="/programmes"
 >
-  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
-    <h1 class="text-3xl sm:text-4xl font-bold text-brand-navy dark:text-white">
+  <div class="bg-brand-primary">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+    <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
       Programmes
     </h1>
-    <p class="mt-2 text-gray-600 dark:text-gray-400 max-w-xl">
+    <p class="mt-2 text-brand-foreground-muted max-w-xl">
       Educational initiatives, competitions, and hands-on trading experience
       for every level.
     </p>
 
     {programmes.length === 0 ? (
-      <p class="mt-10 text-gray-500 dark:text-gray-400">Programmes will be announced soon.</p>
+      <p class="mt-10 text-brand-foreground-muted">Programmes will be announced soon.</p>
     ) : (
       <div class="mt-10 space-y-8">
         {programmes.map((p) => (
-          <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-6 sm:p-8">
+          <div class="bg-white/5 border border-white/10 rounded-xl p-6 sm:p-8">
             <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
               <div class="flex-1">
-                <h2 class="text-xl font-bold text-brand-navy dark:text-white">
+                <h2 class="text-xl font-bold text-brand-foreground">
                   {p.title}
                 </h2>
                 {p.description && (
-                  <p class="mt-2 text-gray-600 dark:text-gray-400 leading-relaxed">
+                  <p class="mt-2 text-brand-foreground-muted leading-relaxed">
                     {p.description}
                   </p>
                 )}
@@ -47,21 +48,21 @@ const programmes = await client.fetch<Array<{
                 <div class="flex gap-6">
                   {p.stats.map((s) => (
                     <div class="text-center">
-                      <div class="text-2xl font-bold text-brand-gold">
+                      <div class="text-2xl font-bold text-brand-accent">
                         {s.value}
                       </div>
-                      <div class="text-xs text-gray-500 dark:text-gray-400">{s.label}</div>
+                      <div class="text-xs text-brand-foreground-muted">{s.label}</div>
                     </div>
                   ))}
                 </div>
               )}
             </div>
             {p.body && (
-              <div class="mt-4 text-sm text-gray-600 dark:text-gray-400 prose prose-sm dark:prose-invert max-w-none" set:html={toHTML(p.body)} />
+              <div class="mt-4 text-sm text-brand-foreground-muted prose prose-sm max-w-none" set:html={toHTML(p.body)} />
             )}
             <a
               href={`/programmes/${p.slug.current}`}
-              class="inline-block mt-4 text-sm font-medium text-brand-gold hover:underline"
+              class="inline-block mt-4 text-sm font-medium text-brand-accent hover:underline"
             >
               Learn more &rarr;
             </a>
@@ -69,5 +70,6 @@ const programmes = await client.fetch<Array<{
         ))}
       </div>
     )}
+    </div>
   </div>
 </BaseLayout>

--- a/src/pages/programmes/queens-tower-capital.astro
+++ b/src/pages/programmes/queens-tower-capital.astro
@@ -1,0 +1,81 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import { client } from "@/lib/sanity";
+import { toHTML } from "@portabletext/to-html";
+
+const programme = await client.fetch<{
+  title: string;
+  slug: { current: string };
+  description?: string;
+  body?: any[];
+  stats?: Array<{ value: string; label: string }>;
+  highlights?: string[];
+}>(`*[_type == "programme" && slug.current == "queens-tower-capital"][0]{
+  title, slug, description, body, stats, highlights
+}`);
+
+const bodyHtml = programme?.body ? toHTML(programme.body) : "";
+---
+
+<BaseLayout
+  title="Queen's Tower Capital"
+  description="ICATS' student-managed quantitative fund. Develop, backtest, and implement trading strategies with real portfolio management and risk assessment."
+  canonical="/programmes/queens-tower-capital"
+>
+  <div class="bg-brand-primary min-h-[60vh]">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+      <a
+        href="/programmes"
+        class="text-sm font-medium text-brand-accent hover:underline"
+      >
+        &larr; All programmes
+      </a>
+
+      {programme ? (
+        <div class="mt-8">
+          <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
+            {programme.title}
+          </h1>
+
+          {programme.description && (
+            <p class="mt-6 text-lg text-brand-foreground leading-relaxed max-w-3xl">
+              {programme.description}
+            </p>
+          )}
+
+          {programme.highlights && programme.highlights.length > 0 && (
+            <div class="mt-8 flex flex-wrap gap-3">
+              {programme.highlights.map((h) => (
+                <span class="px-5 py-2 text-sm font-semibold uppercase tracking-wider text-brand-foreground border border-brand-purple-light rounded-full">
+                  {h}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {programme.stats && programme.stats.length > 0 && (
+            <div class="mt-12 flex gap-10">
+              {programme.stats.map((s) => (
+                <div class="text-center">
+                  <div class="text-3xl font-bold text-brand-accent">{s.value}</div>
+                  <div class="text-sm text-brand-foreground-muted mt-1">{s.label}</div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {bodyHtml && (
+            <div
+              class="mt-12 prose prose-invert prose-lg max-w-none prose-li:text-brand-foreground prose-p:text-brand-foreground"
+              set:html={bodyHtml}
+            />
+          )}
+        </div>
+      ) : (
+        <p class="mt-10 text-brand-foreground-muted">
+          Details for Queen's Tower Capital will be announced soon.
+        </p>
+      )}
+    </div>
+  </div>
+</BaseLayout>

--- a/src/pages/resources.astro
+++ b/src/pages/resources.astro
@@ -27,35 +27,36 @@ const resources = allResources.map((r) => ({
   description="ICATS learning resources: career guides, bootcamp materials, AlgoCourse content, reading lists, and quant session recordings for aspiring traders."
   canonical="/resources"
 >
-  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
-    <h1 class="text-3xl sm:text-4xl font-bold text-brand-navy dark:text-white">
+  <div class="bg-brand-primary">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+    <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
       Resources
     </h1>
-    <p class="mt-2 text-gray-600 dark:text-gray-400 max-w-xl">
+    <p class="mt-2 text-brand-foreground-muted max-w-xl">
       Lecture slides, problem sets, code notebooks, and career guides for
       ICATS members.
     </p>
 
     {resources.length === 0 ? (
-      <p class="mt-10 text-gray-500 dark:text-gray-400">No resources yet. Check back soon.</p>
+      <p class="mt-10 text-brand-foreground-muted">No resources yet. Check back soon.</p>
     ) : (
       <div class="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {resources.map((r) => (
-          <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-5 hover:shadow-md transition-shadow">
+          <div class="bg-white/5 border border-white/10 rounded-xl p-5 hover:shadow-md transition-shadow">
             <div class="flex items-center gap-2 mb-3">
               <span
                 class={`px-2 py-0.5 text-xs font-medium rounded ${
-                  resourceTypeStyles[r.fileType] || "text-gray-600 bg-gray-50"
+                  resourceTypeStyles[r.fileType] || "text-brand-foreground-muted bg-white/5"
                 }`}
               >
                 {resourceTypeLabels[r.fileType] || r.fileType}
               </span>
-              <span class="text-xs text-gray-500 dark:text-gray-400">
+              <span class="text-xs text-brand-foreground-muted">
                 {resourceCategoryLabels[r.category] || r.category}
               </span>
             </div>
-            <h3 class="font-semibold text-brand-navy dark:text-white text-sm">{r.title}</h3>
-            <p class="mt-1 text-xs text-gray-600 dark:text-gray-400 leading-relaxed">
+            <h3 class="font-semibold text-brand-foreground text-sm">{r.title}</h3>
+            <p class="mt-1 text-xs text-brand-foreground-muted leading-relaxed">
               {r.description}
             </p>
             {r.fileUrl ? (
@@ -63,12 +64,12 @@ const resources = allResources.map((r) => ({
                 href={r.fileUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="inline-block mt-3 px-3 py-1.5 text-xs font-medium bg-brand-navy text-white rounded-md hover:bg-brand-dark transition-colors"
+                class="inline-block mt-3 px-3 py-1.5 text-xs font-medium bg-white/10 text-brand-foreground rounded-md hover:bg-white/20 transition-colors"
               >
                 Download
               </a>
             ) : (
-              <span class="inline-block mt-3 px-3 py-1.5 text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 rounded-md">
+              <span class="inline-block mt-3 px-3 py-1.5 text-xs font-medium bg-white/10 text-brand-foreground-muted rounded-md">
                 Coming soon
               </span>
             )}
@@ -76,5 +77,6 @@ const resources = allResources.map((r) => ({
         ))}
       </div>
     )}
+    </div>
   </div>
 </BaseLayout>

--- a/src/pages/sponsors.astro
+++ b/src/pages/sponsors.astro
@@ -64,33 +64,34 @@ const allTiers: { heading: string; tiers: TierConfig[] }[] = [
   description="ICATS industry partners and sponsors from leading quantitative finance and trading firms. Learn about sponsorship opportunities."
   canonical="/sponsors"
 >
-  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
-    <h1 class="text-3xl sm:text-4xl font-bold text-brand-navy dark:text-white">
-      Our Sponsors
+  <div class="bg-brand-primary">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+      <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
+        Our Sponsors
     </h1>
-    <p class="mt-2 text-gray-600 dark:text-gray-400 max-w-xl">
+    <p class="mt-2 text-brand-foreground-muted max-w-xl">
       ICATS is proudly supported by leading firms in quantitative finance,
       algorithmic trading, and technology.
     </p>
 
     {allTiers.map((group) => (
       <Fragment>
-        <h2 class="text-xl font-bold text-brand-navy dark:text-white mt-12 mb-6">
+        <h2 class="text-xl font-bold text-brand-foreground mt-12 mb-6">
           {group.heading}
         </h2>
         <div class="space-y-6">
           {group.tiers.map((t) =>
             t.sponsors.length > 0 && (
-              <div class="rounded-xl p-6 sm:p-8 bg-brand-navy text-white">
+              <div class="rounded-xl p-6 sm:p-8 bg-brand-primary text-brand-foreground">
                 <div class="flex items-center gap-3 mb-6">
-                  <span class="inline-block px-3 py-1 text-xs font-bold rounded-full uppercase tracking-wider bg-brand-gold text-brand-navy">
+                  <span class="inline-block px-3 py-1 text-xs font-bold rounded-full uppercase tracking-wider bg-brand-accent text-brand-primary">
                     {t.tier}
                   </span>
-                  <span class="text-sm text-gray-300">
+                  <span class="text-sm text-brand-foreground">
                     {t.amount}
                   </span>
                 </div>
-                <p class="text-sm mb-6 text-gray-300">
+                <p class="text-sm mb-6 text-brand-foreground">
                   {t.label}
                 </p>
                 <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
@@ -105,20 +106,21 @@ const allTiers: { heading: string; tiers: TierConfig[] }[] = [
       </Fragment>
     ))}
 
-    <div class="mt-16 bg-brand-light dark:bg-gray-900/50 rounded-xl p-8 text-center">
-      <h2 class="text-xl font-bold text-brand-navy dark:text-white">
+    <div class="mt-16 bg-white/5 rounded-xl p-8 text-center">
+      <h2 class="text-xl font-bold text-brand-foreground">
         Interested in Sponsoring ICATS?
       </h2>
-      <p class="mt-2 text-gray-600 dark:text-gray-400 max-w-md mx-auto">
+      <p class="mt-2 text-brand-foreground-muted max-w-md mx-auto">
         Partner with London&apos;s largest university algorithmic trading
         society. Reach 1,000+ ambitious students in STEM.
       </p>
       <a
         href="mailto:algo.trade@imperial.ac.uk"
-        class="inline-block mt-4 px-6 py-3 text-sm font-semibold bg-brand-navy text-white rounded-lg hover:bg-brand-dark transition-colors"
+        class="inline-block mt-4 px-6 py-3 text-sm font-semibold bg-brand-accent text-brand-primary rounded-lg hover:bg-amber-400 transition-colors"
       >
         Get in Touch
       </a>
+    </div>
     </div>
   </div>
 </BaseLayout>

--- a/src/pages/wit.astro
+++ b/src/pages/wit.astro
@@ -24,66 +24,68 @@ const events = await client.fetch<Array<{
   description="ICWiT (Imperial College Women in Trading): promoting gender diversity in quantitative finance through events, mentoring, and industry partnerships."
   canonical="/wit"
 >
-  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
-    <h1 class="text-3xl sm:text-4xl font-bold text-brand-navy dark:text-white">
-      Imperial College Women in Trading
-    </h1>
-    <p class="mt-4 text-lg text-gray-600 dark:text-gray-400 max-w-3xl leading-relaxed">
-      ICWiT is a sub-society within ICATS dedicated to empowering women in
-      quantitative finance, trading, and technology. With {stats.witMembers}{" "}
-      members and {stats.witEvents} events, we provide a supportive
-      community, mentorship, and career opportunities.
-    </p>
-    <a
-      href="https://www.instagram.com/ic.wit/"
-      target="_blank"
-      rel="noopener noreferrer"
-      class="inline-flex items-center gap-2 mt-4 text-sm font-medium text-brand-navy dark:text-white hover:text-brand-gold transition-colors"
-    >
-      <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zM12 16a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 100 2.881 1.44 1.44 0 000-2.881z"/></svg>
-      @ic.wit
-    </a>
+  <div class="bg-brand-primary">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+      <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
+        Imperial College Women in Trading
+      </h1>
+      <p class="mt-4 text-lg text-brand-foreground-muted max-w-3xl leading-relaxed">
+        ICWiT is a sub-society within ICATS dedicated to empowering women in
+        quantitative finance, trading, and technology. With {stats.witMembers}{" "}
+        members and {stats.witEvents} events, we provide a supportive
+        community, mentorship, and career opportunities.
+      </p>
+      <a
+        href="https://www.instagram.com/ic.wit/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center gap-2 mt-4 text-sm font-medium text-brand-foreground hover:text-brand-accent transition-colors"
+      >
+        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zM12 16a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 100 2.881 1.44 1.44 0 000-2.881z"/></svg>
+        @ic.wit
+      </a>
 
-    <div class="mt-12 grid grid-cols-1 sm:grid-cols-2 gap-6">
-      <div class="bg-brand-green/10 border border-brand-green/20 rounded-xl p-6 text-center">
-        <div class="text-3xl font-bold text-brand-navy dark:text-white">{stats.witMembers}</div>
-        <div class="text-sm text-gray-600 dark:text-gray-400 mt-1">Members</div>
-      </div>
-      <div class="bg-brand-green/10 border border-brand-green/20 rounded-xl p-6 text-center">
-        <div class="text-3xl font-bold text-brand-navy dark:text-white">{stats.witEvents}</div>
-        <div class="text-sm text-gray-600 dark:text-gray-400 mt-1">Campus Events</div>
-      </div>
-    </div>
-
-    <h2 class="text-xl font-bold text-brand-navy dark:text-white mt-16 mb-6">
-      Our Events
-    </h2>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      {events.map((e) => (
-        <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-5 hover:shadow-md transition-shadow">
-          <h3 class="font-semibold text-brand-navy dark:text-white">{e.title}</h3>
-          <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{e.description}</p>
+      <div class="mt-12 grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <div class="bg-brand-highlight/10 border border-brand-highlight/20 rounded-xl p-6 text-center">
+          <div class="text-3xl font-bold text-brand-foreground">{stats.witMembers}</div>
+          <div class="text-sm text-brand-foreground-muted mt-1">Members</div>
         </div>
-      ))}
-    </div>
+        <div class="bg-brand-highlight/10 border border-brand-highlight/20 rounded-xl p-6 text-center">
+          <div class="text-3xl font-bold text-brand-foreground">{stats.witEvents}</div>
+          <div class="text-sm text-brand-foreground-muted mt-1">Campus Events</div>
+        </div>
+      </div>
 
-    <h2 class="text-xl font-bold text-brand-navy dark:text-white mt-16 mb-6">
-      ICWiT Leadership
-    </h2>
-    {witMembers.length > 0 ? (
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-        {witMembers.map((m) => (
-          <MemberCard
-            name={m.name}
-            role={m.role}
-            photo={m.photoUrl || ""}
-            bio={m.bio || undefined}
-            linkedIn={m.linkedIn || undefined}
-          />
+      <h2 class="text-xl font-bold text-brand-foreground mt-16 mb-6">
+        Our Events
+      </h2>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {events.map((e) => (
+          <div class="bg-white/5 border border-white/10 rounded-xl p-5 hover:shadow-md transition-shadow">
+            <h3 class="font-semibold text-brand-foreground">{e.title}</h3>
+            <p class="mt-1 text-sm text-brand-foreground-muted">{e.description}</p>
+          </div>
         ))}
       </div>
-    ) : (
-      <p class="text-gray-500 dark:text-gray-400">ICWiT committee members will be announced soon.</p>
-    )}
+
+      <h2 class="text-xl font-bold text-brand-foreground mt-16 mb-6">
+        ICWiT Leadership
+      </h2>
+      {witMembers.length > 0 ? (
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          {witMembers.map((m) => (
+            <MemberCard
+              name={m.name}
+              role={m.role}
+              photo={m.photoUrl || ""}
+              bio={m.bio || undefined}
+              linkedIn={m.linkedIn || undefined}
+            />
+          ))}
+        </div>
+      ) : (
+        <p class="text-brand-foreground-muted">ICWiT committee members will be announced soon.</p>
+      )}
+    </div>
   </div>
 </BaseLayout>

--- a/src/sanity/schemas/programme.ts
+++ b/src/sanity/schemas/programme.ts
@@ -31,6 +31,13 @@ export default defineType({
         },
       ],
     }),
+    defineField({
+      name: "highlights",
+      title: "Highlights",
+      description: "Short tags displayed as pills on the programme page (e.g. 'Real Trading')",
+      type: "array",
+      of: [{ type: "string" }],
+    }),
     defineField({ name: "sortOrder", title: "Sort Order", type: "number", initialValue: 99 }),
   ],
   orderings: [{ title: "Sort Order", name: "sortOrder", by: [{ field: "sortOrder", direction: "asc" }] }],

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,18 +3,21 @@
 
 /*
  * Brand colour tokens -- single source of truth.
- * Use Tailwind classes (e.g. bg-brand-navy, text-brand-gold).
+ * Use Tailwind classes (e.g. bg-brand-primary, text-brand-accent).
  * Do not hardcode hex values in components.
  */
 @theme inline {
-  /* Core palette */
-  --color-brand-navy: #0F172A;
-  --color-brand-dark: #0F172A;
-  --color-brand-dark-slate: #1E293B;
-  --color-brand-gold: #F59E0B;
-  --color-brand-green: #10B981;
-  --color-brand-light: #F8FAFC;
-  --color-brand-gray: #64748B;
+  /* Core */
+  --color-brand-primary: #2B2B2B;
+  --color-brand-slate: #1E293B;
+  --color-brand-accent: #F59E0B;
+  --color-brand-highlight: #10B981;
+  --color-brand-surface: #F8FAFC;
+  --color-brand-muted: #64748B;
+
+  /* Foreground (text on dark surfaces) */
+  --color-brand-foreground: #E1E8EF;
+  --color-brand-foreground-muted: #9CA3AF;
 
   /* Purple accent */
   --color-brand-purple: #6B46C1;
@@ -41,7 +44,7 @@ h1, h2 {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-brand-light: #111827;
+    --color-brand-surface: #111827;
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `/programmes/queens-tower-capital` page with highlights pills, stats, and body content from Sanity
- Renames all brand colour tokens to semantic names (e.g. `brand-navy` -> `brand-primary`, `brand-gold` -> `brand-accent`)
- Changes primary dark colour from navy (#0F172A) to charcoal (#2B2B2B) with new `brand-foreground` (#E1E8EF) and `brand-foreground-muted` (#9CA3AF) tokens for text
- Converts all 18 pages and components to forced-dark backgrounds, removing all `dark:` mode variants for a consistent design

## Test plan
- [ ] `npm run build` passes
- [ ] Every page renders with charcoal background and ice/stone text
- [ ] No invisible buttons (check About, Sponsors, Events, Resources CTAs)
- [ ] Sponsor logos visible on tier cards and programme pages
- [ ] Brand page at `/brand` shows updated swatches and component examples
- [ ] Deploy Sanity Studio (`npx sanity deploy`) for new programme highlights field
- [ ] Test Safari, Chrome, Edge