### PR TITLE
Add Bootcamp programme page

### DIFF
--- a/src/pages/programmes/bootcamp.astro
+++ b/src/pages/programmes/bootcamp.astro
@@ -1,0 +1,102 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+---
+
+<BaseLayout
+  title="Bootcamp"
+  description="ICATS Bootcamp: a pre-requisite crash course for AlgoCourse, covering foundational concepts in quantitative trading. Accessible to all backgrounds."
+  canonical="/programmes/bootcamp"
+>
+  <div class="bg-brand-primary">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+      <a
+        href="/programmes"
+        class="text-sm font-medium text-brand-accent hover:underline"
+      >
+        &larr; All programmes
+      </a>
+
+      <div class="mt-8">
+        <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
+          Bootcamp
+        </h1>
+        <p class="mt-6 text-lg text-brand-foreground leading-relaxed max-w-3xl">
+          A pre-requisite crash course for the AlgoCourse, covering
+          foundational concepts for members new to quantitative trading.
+          No prior experience required.
+        </p>
+
+        <div class="mt-8 flex flex-wrap gap-3">
+          <span class="px-4 py-1.5 text-xs font-medium bg-white/10 text-brand-foreground-muted rounded-full">
+            All Backgrounds Welcome
+          </span>
+          <span class="px-4 py-1.5 text-xs font-medium bg-white/10 text-brand-foreground-muted rounded-full">
+            Feeds into AlgoCourse
+          </span>
+          <span class="px-4 py-1.5 text-xs font-medium bg-white/10 text-brand-foreground-muted rounded-full">
+            Hands-on Coding
+          </span>
+        </div>
+
+        <h2 class="text-2xl font-bold text-brand-foreground mt-16 mb-8">
+          What You'll Learn
+        </h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div class="bg-white/5 border border-white/10 rounded-xl p-5">
+            <div class="flex items-baseline gap-3">
+              <span class="text-sm font-bold text-brand-accent">01</span>
+              <h3 class="font-semibold text-brand-foreground">Market Microstructure</h3>
+            </div>
+            <p class="mt-2 text-sm text-brand-foreground-muted">
+              Order books, price formation, and the economics of the bid-ask spread.
+            </p>
+          </div>
+          <div class="bg-white/5 border border-white/10 rounded-xl p-5">
+            <div class="flex items-baseline gap-3">
+              <span class="text-sm font-bold text-brand-accent">02</span>
+              <h3 class="font-semibold text-brand-foreground">Python Fundamentals</h3>
+            </div>
+            <p class="mt-2 text-sm text-brand-foreground-muted">
+              Core Python for working with financial data, libraries, and basic analysis.
+            </p>
+          </div>
+          <div class="bg-white/5 border border-white/10 rounded-xl p-5">
+            <div class="flex items-baseline gap-3">
+              <span class="text-sm font-bold text-brand-accent">03</span>
+              <h3 class="font-semibold text-brand-foreground">Trading Concepts</h3>
+            </div>
+            <p class="mt-2 text-sm text-brand-foreground-muted">
+              Introduction to algorithmic trading, strategy types, and key terminology.
+            </p>
+          </div>
+          <div class="bg-white/5 border border-white/10 rounded-xl p-5">
+            <div class="flex items-baseline gap-3">
+              <span class="text-sm font-bold text-brand-accent">04</span>
+              <h3 class="font-semibold text-brand-foreground">Hands-on Exercises</h3>
+            </div>
+            <p class="mt-2 text-sm text-brand-foreground-muted">
+              Practical coding exercises to reinforce concepts and prepare for AlgoCourse.
+            </p>
+          </div>
+        </div>
+
+        <div class="mt-16 bg-white/5 border border-white/10 rounded-xl p-8">
+          <h2 class="text-xl font-bold text-brand-foreground">
+            Ready for More?
+          </h2>
+          <p class="mt-2 text-brand-foreground-muted max-w-2xl">
+            Bootcamp is designed as a stepping stone into AlgoCourse, our
+            intensive 8-week programme. Complete the Bootcamp and you'll have
+            everything you need to hit the ground running.
+          </p>
+          <a
+            href="/programmes/algocourse"
+            class="inline-block mt-4 text-sm font-medium text-brand-accent hover:underline"
+          >
+            View AlgoCourse &rarr;
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- Adds `/programmes/bootcamp` static page for the AlgoCourse pre-requisite crash course
- Content sourced from Sanity export data (programme description, bullet points, session topics)
- Includes curriculum grid, tags, and CTA linking through to AlgoCourse

## Test plan
- [ ] `npm run build` passes
- [ ] `/programmes/bootcamp` renders correctly
- [ ] Link from `/programmes` listing resolves (slug: bootcamp)
- [ ] AlgoCourse link at bottom works