### PR TITLE
Add Weekly Quant Sessions programme page

### DIFF
--- a/scripts/create-weekly-quant-sessions.mjs
+++ b/scripts/create-weekly-quant-sessions.mjs
@@ -1,0 +1,118 @@
+// One-time script to create the Weekly Quant Sessions programme document in Sanity.
+// Usage: SANITY_TOKEN=<token> node scripts/create-weekly-quant-sessions.mjs
+
+import "dotenv/config";
+import { createClient } from "@sanity/client";
+
+const client = createClient({
+  projectId: "bd3zp068",
+  dataset: "production",
+  apiVersion: "2024-01-01",
+  useCdn: false,
+  token: process.env.SANITY_TOKEN,
+});
+
+if (!process.env.SANITY_TOKEN) {
+  console.error("Set SANITY_TOKEN env var (create one at sanity.io/manage -> API -> Tokens)");
+  process.exit(1);
+}
+
+const doc = {
+  _id: "programme-weekly-quant-sessions",
+  _type: "programme",
+  title: "Weekly Quant Sessions",
+  slug: { _type: "slug", current: "weekly-quant-sessions" },
+  description:
+    "Weekly collaborative sessions where members tackle quantitative finance problems, explore new strategies, and sharpen their analytical skills together.",
+  highlights: ["Weekly", "Collaborative", "All Levels"],
+  stats: [
+    { _key: "freq", value: "Weekly", label: "Frequency" },
+  ],
+  body: [
+    {
+      _type: "block",
+      _key: "h1",
+      style: "h2",
+      children: [{ _type: "span", _key: "s1", text: "What are Weekly Quant Sessions?" }],
+      markDefs: [],
+    },
+    {
+      _type: "block",
+      _key: "p1",
+      style: "normal",
+      children: [
+        {
+          _type: "span",
+          _key: "s2",
+          text: "Weekly Quant Sessions are informal, collaborative meetups where ICATS members work through quantitative finance problems together. Each session focuses on a different topic, from brainteasers and probability puzzles to real-world strategy development and data analysis.",
+        },
+      ],
+      markDefs: [],
+    },
+    {
+      _type: "block",
+      _key: "h2",
+      style: "h2",
+      children: [{ _type: "span", _key: "s3", text: "What to expect" }],
+      markDefs: [],
+    },
+    {
+      _type: "block",
+      _key: "l1",
+      style: "normal",
+      listItem: "bullet",
+      level: 1,
+      children: [{ _type: "span", _key: "s4", text: "Hands-on problem-solving in small groups" }],
+      markDefs: [],
+    },
+    {
+      _type: "block",
+      _key: "l2",
+      style: "normal",
+      listItem: "bullet",
+      level: 1,
+      children: [{ _type: "span", _key: "s5", text: "Topics spanning probability, statistics, and quantitative strategy" }],
+      markDefs: [],
+    },
+    {
+      _type: "block",
+      _key: "l3",
+      style: "normal",
+      listItem: "bullet",
+      level: 1,
+      children: [{ _type: "span", _key: "s6", text: "A relaxed environment to learn from peers and build intuition" }],
+      markDefs: [],
+    },
+    {
+      _type: "block",
+      _key: "l4",
+      style: "normal",
+      listItem: "bullet",
+      level: 1,
+      children: [{ _type: "span", _key: "s7", text: "Great preparation for quant interviews and trading challenges" }],
+      markDefs: [],
+    },
+  ],
+  sortOrder: 4,
+};
+
+async function main() {
+  const existing = await client.fetch(
+    `*[_type == "programme" && slug.current == "weekly-quant-sessions"][0]{ _id }`
+  );
+
+  if (existing) {
+    console.log(`Programme already exists (${existing._id}), updating...`);
+    await client.createOrReplace({ ...doc, _id: existing._id });
+  } else {
+    console.log("Creating Weekly Quant Sessions programme...");
+    await client.createOrReplace(doc);
+  }
+
+  console.log("Done! Weekly Quant Sessions programme created in Sanity.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/pages/programmes/weekly-quant-sessions.astro
+++ b/src/pages/programmes/weekly-quant-sessions.astro
@@ -1,0 +1,81 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import { client } from "@/lib/sanity";
+import { toHTML } from "@portabletext/to-html";
+
+const programme = await client.fetch<{
+  title: string;
+  slug: { current: string };
+  description?: string;
+  body?: any[];
+  stats?: Array<{ value: string; label: string }>;
+  highlights?: string[];
+}>(`*[_type == "programme" && slug.current == "weekly-quant-sessions"][0]{
+  title, slug, description, body, stats, highlights
+}`);
+
+const bodyHtml = programme?.body ? toHTML(programme.body) : "";
+---
+
+<BaseLayout
+  title="Weekly Quant Sessions"
+  description="Weekly collaborative sessions exploring quantitative finance topics, problem-solving, and strategy development with fellow Imperial students."
+  canonical="/programmes/weekly-quant-sessions"
+>
+  <div class="bg-brand-primary min-h-[60vh]">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+      <a
+        href="/programmes"
+        class="text-sm font-medium text-brand-accent hover:underline"
+      >
+        &larr; All programmes
+      </a>
+
+      {programme ? (
+        <div class="mt-8">
+          <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
+            {programme.title}
+          </h1>
+
+          {programme.description && (
+            <p class="mt-6 text-lg text-brand-foreground leading-relaxed max-w-3xl">
+              {programme.description}
+            </p>
+          )}
+
+          {programme.highlights && programme.highlights.length > 0 && (
+            <div class="mt-8 flex flex-wrap gap-3">
+              {programme.highlights.map((h) => (
+                <span class="px-4 py-1.5 text-xs font-medium bg-white/10 text-brand-foreground-muted rounded-full">
+                  {h}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {programme.stats && programme.stats.length > 0 && (
+            <div class="mt-12 flex gap-10">
+              {programme.stats.map((s) => (
+                <div class="text-center">
+                  <div class="text-3xl font-bold text-brand-accent">{s.value}</div>
+                  <div class="text-sm text-brand-foreground-muted mt-1">{s.label}</div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {bodyHtml && (
+            <div
+              class="mt-12 prose prose-invert prose-lg max-w-none prose-li:text-brand-foreground prose-p:text-brand-foreground"
+              set:html={bodyHtml}
+            />
+          )}
+        </div>
+      ) : (
+        <p class="mt-10 text-brand-foreground-muted">
+          Details for Weekly Quant Sessions will be announced soon.
+        </p>
+      )}
+    </div>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- New Sanity-driven programme page at `/programmes/weekly-quant-sessions`
- Follows the same pattern as Markets 101 and Queen's Tower Capital
- One-time Sanity import script for the programme document

Closes #16

## Test plan
- [ ] Verify `/programmes/weekly-quant-sessions` renders title, description, highlights, stats, and body from Sanity
- [ ] Verify `/programmes` index shows the card with only title, description, and stats
- [ ] Test in Safari, Chrome, and Edge (light and dark mode)
- [ ] Confirm other programme pages are unaffected