### PR TITLE
Migrate AlgoCourse and Bootcamp pages to Sanity

### DIFF
--- a/scripts/create-algocourse.mjs
+++ b/scripts/create-algocourse.mjs
@@ -1,0 +1,65 @@
+// One-time script to create/update the AlgoCourse programme document in Sanity.
+// Usage: SANITY_TOKEN=<token> node scripts/create-algocourse.mjs
+
+import "dotenv/config";
+import { createClient } from "@sanity/client";
+
+const client = createClient({
+  projectId: "bd3zp068",
+  dataset: "production",
+  apiVersion: "2024-01-01",
+  useCdn: false,
+  token: process.env.SANITY_TOKEN,
+});
+
+if (!process.env.SANITY_TOKEN) {
+  console.error("Set SANITY_TOKEN env var (create one at sanity.io/manage -> API -> Tokens)");
+  process.exit(1);
+}
+
+const doc = {
+  _id: "programme-algocourse",
+  _type: "programme",
+  title: "AlgoCourse",
+  slug: { _type: "slug", current: "algocourse" },
+  description:
+    "An intensive 8-week comprehensive course covering all fundamentals needed for a successful career in financial markets. Taught by fellow Imperial students with industry internship experience, covering everything from Python basics to advanced trading strategies.",
+  highlights: ["8 Weeks", "Python to Strategies", "Taught by Students"],
+  stats: [
+    { _key: "weeks", value: "8", label: "Weeks" },
+    { _key: "attendees", value: "520+", label: "Past Attendees" },
+    { _key: "lectures", value: "7", label: "Lectures" },
+  ],
+  curriculum: [
+    { _key: "w1", label: "Week 1", title: "Python Fundamentals", description: "Core Python for finance: data types, control flow, functions, and libraries." },
+    { _key: "w2", label: "Week 2", title: "Data Analysis", description: "NumPy, pandas, and data wrangling for financial datasets." },
+    { _key: "w3", label: "Week 3", title: "Market Microstructure", description: "Order books, price formation, and the economics of the bid-ask spread." },
+    { _key: "w4", label: "Week 4", title: "Statistical Foundations", description: "Probability, distributions, hypothesis testing, and time series analysis." },
+    { _key: "w5", label: "Week 5", title: "Signal Generation", description: "Alpha research, factor models, and building trading signals from data." },
+    { _key: "w6", label: "Week 6", title: "Backtesting", description: "Strategy evaluation, avoiding overfitting, and performance metrics." },
+    { _key: "w7", label: "Week 7", title: "Options & Derivatives", description: "Options pricing, Greeks, volatility surfaces, and basic strategies." },
+    { _key: "w8", label: "Week 8", title: "Execution & ML", description: "Execution algorithms, slippage, and machine learning applications in trading." },
+  ],
+  sortOrder: 1,
+};
+
+async function main() {
+  const existing = await client.fetch(
+    `*[_type == "programme" && slug.current == "algocourse"][0]{ _id }`
+  );
+
+  if (existing) {
+    console.log(`Programme already exists (${existing._id}), updating...`);
+    await client.createOrReplace({ ...doc, _id: existing._id });
+  } else {
+    console.log("Creating AlgoCourse programme...");
+    await client.createOrReplace(doc);
+  }
+
+  console.log("Done! AlgoCourse programme created in Sanity.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/create-bootcamp.mjs
+++ b/scripts/create-bootcamp.mjs
@@ -1,0 +1,79 @@
+// One-time script to create/update the Bootcamp programme document in Sanity.
+// Usage: SANITY_TOKEN=<token> node scripts/create-bootcamp.mjs
+
+import "dotenv/config";
+import { createClient } from "@sanity/client";
+
+const client = createClient({
+  projectId: "bd3zp068",
+  dataset: "production",
+  apiVersion: "2024-01-01",
+  useCdn: false,
+  token: process.env.SANITY_TOKEN,
+});
+
+if (!process.env.SANITY_TOKEN) {
+  console.error("Set SANITY_TOKEN env var (create one at sanity.io/manage -> API -> Tokens)");
+  process.exit(1);
+}
+
+const doc = {
+  _id: "programme-bootcamp",
+  _type: "programme",
+  title: "Bootcamp",
+  slug: { _type: "slug", current: "bootcamp" },
+  description:
+    "A pre-requisite crash course for the AlgoCourse, covering foundational concepts for members new to quantitative trading. No prior experience required.",
+  highlights: ["All Backgrounds Welcome", "Feeds into AlgoCourse", "Hands-on Coding"],
+  stats: [],
+  curriculum: [
+    { _key: "t1", label: "01", title: "Market Microstructure", description: "Order books, price formation, and the economics of the bid-ask spread." },
+    { _key: "t2", label: "02", title: "Python Fundamentals", description: "Core Python for working with financial data, libraries, and basic analysis." },
+    { _key: "t3", label: "03", title: "Trading Concepts", description: "Introduction to algorithmic trading, strategy types, and key terminology." },
+    { _key: "t4", label: "04", title: "Hands-on Exercises", description: "Practical coding exercises to reinforce concepts and prepare for AlgoCourse." },
+  ],
+  body: [
+    {
+      _type: "block",
+      _key: "cta-heading",
+      style: "h2",
+      children: [{ _type: "span", _key: "s1", text: "Ready for More?" }],
+      markDefs: [],
+    },
+    {
+      _type: "block",
+      _key: "cta-body",
+      style: "normal",
+      children: [
+        {
+          _type: "span",
+          _key: "s2",
+          text: "Bootcamp is designed as a stepping stone into AlgoCourse, our intensive 8-week programme. Complete the Bootcamp and you'll have everything you need to hit the ground running.",
+        },
+      ],
+      markDefs: [],
+    },
+  ],
+  sortOrder: 2,
+};
+
+async function main() {
+  const existing = await client.fetch(
+    `*[_type == "programme" && slug.current == "bootcamp"][0]{ _id }`
+  );
+
+  if (existing) {
+    console.log(`Programme already exists (${existing._id}), updating...`);
+    await client.createOrReplace({ ...doc, _id: existing._id });
+  } else {
+    console.log("Creating Bootcamp programme...");
+    await client.createOrReplace(doc);
+  }
+
+  console.log("Done! Bootcamp programme created in Sanity.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/pages/programmes/algocourse.astro
+++ b/src/pages/programmes/algocourse.astro
@@ -1,16 +1,21 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import { client } from "@/lib/sanity";
+import { toHTML } from "@portabletext/to-html";
 
-const weeks = [
-  { number: 1, title: "Python Fundamentals", description: "Core Python for finance: data types, control flow, functions, and libraries." },
-  { number: 2, title: "Data Analysis", description: "NumPy, pandas, and data wrangling for financial datasets." },
-  { number: 3, title: "Market Microstructure", description: "Order books, price formation, and the economics of the bid-ask spread." },
-  { number: 4, title: "Statistical Foundations", description: "Probability, distributions, hypothesis testing, and time series analysis." },
-  { number: 5, title: "Signal Generation", description: "Alpha research, factor models, and building trading signals from data." },
-  { number: 6, title: "Backtesting", description: "Strategy evaluation, avoiding overfitting, and performance metrics." },
-  { number: 7, title: "Options & Derivatives", description: "Options pricing, Greeks, volatility surfaces, and basic strategies." },
-  { number: 8, title: "Execution & ML", description: "Execution algorithms, slippage, and machine learning applications in trading." },
-];
+const programme = await client.fetch<{
+  title: string;
+  slug: { current: string };
+  description?: string;
+  body?: any[];
+  stats?: Array<{ value: string; label: string }>;
+  highlights?: string[];
+  curriculum?: Array<{ label: string; title: string; description: string }>;
+}>(`*[_type == "programme" && slug.current == "algocourse"][0]{
+  title, slug, description, body, stats, highlights, curriculum
+}`);
+
+const bodyHtml = programme?.body ? toHTML(programme.body) : "";
 ---
 
 <BaseLayout
@@ -18,7 +23,7 @@ const weeks = [
   description="An intensive 8-week course covering the fundamentals needed for a career in financial markets. Taught by Imperial students with industry experience."
   canonical="/programmes/algocourse"
 >
-  <div class="bg-brand-primary">
+  <div class="bg-brand-primary min-h-[60vh]">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
       <a
         href="/programmes"
@@ -27,59 +32,70 @@ const weeks = [
         &larr; All programmes
       </a>
 
-      <div class="mt-8">
-        <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
-          AlgoCourse
-        </h1>
-        <p class="mt-6 text-lg text-brand-foreground leading-relaxed max-w-3xl">
-          An intensive 8-week comprehensive course covering all fundamentals
-          needed for a successful career in financial markets. Taught by fellow
-          Imperial students with industry internship experience, covering
-          everything from Python basics to advanced trading strategies.
-        </p>
+      {programme ? (
+        <div class="mt-8">
+          <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
+            {programme.title}
+          </h1>
 
-        <div class="mt-8 flex flex-wrap gap-3">
-          <span class="px-4 py-1.5 text-xs font-medium bg-white/10 text-brand-foreground-muted rounded-full">
-            8 Weeks
-          </span>
-          <span class="px-4 py-1.5 text-xs font-medium bg-white/10 text-brand-foreground-muted rounded-full">
-            Python to Strategies
-          </span>
-          <span class="px-4 py-1.5 text-xs font-medium bg-white/10 text-brand-foreground-muted rounded-full">
-            Taught by Students
-          </span>
-        </div>
+          {programme.description && (
+            <p class="mt-6 text-lg text-brand-foreground leading-relaxed max-w-3xl">
+              {programme.description}
+            </p>
+          )}
 
-        <div class="mt-12 flex gap-10">
-          <div class="text-center">
-            <div class="text-3xl font-bold text-brand-accent">8</div>
-            <div class="text-sm text-brand-foreground-muted mt-1">Weeks</div>
-          </div>
-          <div class="text-center">
-            <div class="text-3xl font-bold text-brand-accent">520+</div>
-            <div class="text-sm text-brand-foreground-muted mt-1">Past Attendees</div>
-          </div>
-          <div class="text-center">
-            <div class="text-3xl font-bold text-brand-accent">7</div>
-            <div class="text-sm text-brand-foreground-muted mt-1">Lectures</div>
-          </div>
-        </div>
-
-        <h2 class="text-2xl font-bold text-brand-foreground mt-16 mb-8">
-          Curriculum
-        </h2>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {weeks.map((w) => (
-            <div class="bg-white/5 border border-white/10 rounded-xl p-5">
-              <div class="flex items-baseline gap-3">
-                <span class="text-sm font-bold text-brand-accent">Week {w.number}</span>
-                <h3 class="font-semibold text-brand-foreground">{w.title}</h3>
-              </div>
-              <p class="mt-2 text-sm text-brand-foreground-muted">{w.description}</p>
+          {programme.highlights && programme.highlights.length > 0 && (
+            <div class="mt-8 flex flex-wrap gap-3">
+              {programme.highlights.map((h) => (
+                <span class="px-4 py-1.5 text-xs font-medium bg-white/10 text-brand-foreground-muted rounded-full">
+                  {h}
+                </span>
+              ))}
             </div>
-          ))}
+          )}
+
+          {programme.stats && programme.stats.length > 0 && (
+            <div class="mt-12 flex gap-10">
+              {programme.stats.map((s) => (
+                <div class="text-center">
+                  <div class="text-3xl font-bold text-brand-accent">{s.value}</div>
+                  <div class="text-sm text-brand-foreground-muted mt-1">{s.label}</div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {programme.curriculum && programme.curriculum.length > 0 && (
+            <>
+              <h2 class="text-2xl font-bold text-brand-foreground mt-16 mb-8">
+                Curriculum
+              </h2>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {programme.curriculum.map((item) => (
+                  <div class="bg-white/5 border border-white/10 rounded-xl p-5">
+                    <div class="flex items-baseline gap-3">
+                      <span class="text-sm font-bold text-brand-accent">{item.label}</span>
+                      <h3 class="font-semibold text-brand-foreground">{item.title}</h3>
+                    </div>
+                    <p class="mt-2 text-sm text-brand-foreground-muted">{item.description}</p>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+
+          {bodyHtml && (
+            <div
+              class="mt-12 prose prose-invert prose-lg max-w-none prose-li:text-brand-foreground prose-p:text-brand-foreground"
+              set:html={bodyHtml}
+            />
+          )}
         </div>
-      </div>
+      ) : (
+        <p class="mt-10 text-brand-foreground-muted">
+          Details for AlgoCourse will be announced soon.
+        </p>
+      )}
     </div>
   </div>
 </BaseLayout>

--- a/src/pages/programmes/bootcamp.astro
+++ b/src/pages/programmes/bootcamp.astro
@@ -1,5 +1,21 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import { client } from "@/lib/sanity";
+import { toHTML } from "@portabletext/to-html";
+
+const programme = await client.fetch<{
+  title: string;
+  slug: { current: string };
+  description?: string;
+  body?: any[];
+  stats?: Array<{ value: string; label: string }>;
+  highlights?: string[];
+  curriculum?: Array<{ label: string; title: string; description: string }>;
+}>(`*[_type == "programme" && slug.current == "bootcamp"][0]{
+  title, slug, description, body, stats, highlights, curriculum
+}`);
+
+const bodyHtml = programme?.body ? toHTML(programme.body) : "";
 ---
 
 <BaseLayout
@@ -7,7 +23,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
   description="ICATS Bootcamp: a pre-requisite crash course for AlgoCourse, covering foundational concepts in quantitative trading. Accessible to all backgrounds."
   canonical="/programmes/bootcamp"
 >
-  <div class="bg-brand-primary">
+  <div class="bg-brand-primary min-h-[60vh]">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
       <a
         href="/programmes"
@@ -16,87 +32,70 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
         &larr; All programmes
       </a>
 
-      <div class="mt-8">
-        <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
-          Bootcamp
-        </h1>
-        <p class="mt-6 text-lg text-brand-foreground leading-relaxed max-w-3xl">
-          A pre-requisite crash course for the AlgoCourse, covering
-          foundational concepts for members new to quantitative trading.
-          No prior experience required.
+      {programme ? (
+        <div class="mt-8">
+          <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
+            {programme.title}
+          </h1>
+
+          {programme.description && (
+            <p class="mt-6 text-lg text-brand-foreground leading-relaxed max-w-3xl">
+              {programme.description}
+            </p>
+          )}
+
+          {programme.highlights && programme.highlights.length > 0 && (
+            <div class="mt-8 flex flex-wrap gap-3">
+              {programme.highlights.map((h) => (
+                <span class="px-4 py-1.5 text-xs font-medium bg-white/10 text-brand-foreground-muted rounded-full">
+                  {h}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {programme.stats && programme.stats.length > 0 && (
+            <div class="mt-12 flex gap-10">
+              {programme.stats.map((s) => (
+                <div class="text-center">
+                  <div class="text-3xl font-bold text-brand-accent">{s.value}</div>
+                  <div class="text-sm text-brand-foreground-muted mt-1">{s.label}</div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {programme.curriculum && programme.curriculum.length > 0 && (
+            <>
+              <h2 class="text-2xl font-bold text-brand-foreground mt-16 mb-8">
+                What You'll Learn
+              </h2>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {programme.curriculum.map((item) => (
+                  <div class="bg-white/5 border border-white/10 rounded-xl p-5">
+                    <div class="flex items-baseline gap-3">
+                      <span class="text-sm font-bold text-brand-accent">{item.label}</span>
+                      <h3 class="font-semibold text-brand-foreground">{item.title}</h3>
+                    </div>
+                    <p class="mt-2 text-sm text-brand-foreground-muted">{item.description}</p>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+
+          {bodyHtml && (
+            <div
+              class="mt-12 prose prose-invert prose-lg max-w-none prose-li:text-brand-foreground prose-p:text-brand-foreground"
+              set:html={bodyHtml}
+            />
+          )}
+        </div>
+      ) : (
+        <p class="mt-10 text-brand-foreground-muted">
+          Details for Bootcamp will be announced soon.
         </p>
-
-        <div class="mt-8 flex flex-wrap gap-3">
-          <span class="px-4 py-1.5 text-xs font-medium bg-white/10 text-brand-foreground-muted rounded-full">
-            All Backgrounds Welcome
-          </span>
-          <span class="px-4 py-1.5 text-xs font-medium bg-white/10 text-brand-foreground-muted rounded-full">
-            Feeds into AlgoCourse
-          </span>
-          <span class="px-4 py-1.5 text-xs font-medium bg-white/10 text-brand-foreground-muted rounded-full">
-            Hands-on Coding
-          </span>
-        </div>
-
-        <h2 class="text-2xl font-bold text-brand-foreground mt-16 mb-8">
-          What You'll Learn
-        </h2>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div class="bg-white/5 border border-white/10 rounded-xl p-5">
-            <div class="flex items-baseline gap-3">
-              <span class="text-sm font-bold text-brand-accent">01</span>
-              <h3 class="font-semibold text-brand-foreground">Market Microstructure</h3>
-            </div>
-            <p class="mt-2 text-sm text-brand-foreground-muted">
-              Order books, price formation, and the economics of the bid-ask spread.
-            </p>
-          </div>
-          <div class="bg-white/5 border border-white/10 rounded-xl p-5">
-            <div class="flex items-baseline gap-3">
-              <span class="text-sm font-bold text-brand-accent">02</span>
-              <h3 class="font-semibold text-brand-foreground">Python Fundamentals</h3>
-            </div>
-            <p class="mt-2 text-sm text-brand-foreground-muted">
-              Core Python for working with financial data, libraries, and basic analysis.
-            </p>
-          </div>
-          <div class="bg-white/5 border border-white/10 rounded-xl p-5">
-            <div class="flex items-baseline gap-3">
-              <span class="text-sm font-bold text-brand-accent">03</span>
-              <h3 class="font-semibold text-brand-foreground">Trading Concepts</h3>
-            </div>
-            <p class="mt-2 text-sm text-brand-foreground-muted">
-              Introduction to algorithmic trading, strategy types, and key terminology.
-            </p>
-          </div>
-          <div class="bg-white/5 border border-white/10 rounded-xl p-5">
-            <div class="flex items-baseline gap-3">
-              <span class="text-sm font-bold text-brand-accent">04</span>
-              <h3 class="font-semibold text-brand-foreground">Hands-on Exercises</h3>
-            </div>
-            <p class="mt-2 text-sm text-brand-foreground-muted">
-              Practical coding exercises to reinforce concepts and prepare for AlgoCourse.
-            </p>
-          </div>
-        </div>
-
-        <div class="mt-16 bg-white/5 border border-white/10 rounded-xl p-8">
-          <h2 class="text-xl font-bold text-brand-foreground">
-            Ready for More?
-          </h2>
-          <p class="mt-2 text-brand-foreground-muted max-w-2xl">
-            Bootcamp is designed as a stepping stone into AlgoCourse, our
-            intensive 8-week programme. Complete the Bootcamp and you'll have
-            everything you need to hit the ground running.
-          </p>
-          <a
-            href="/programmes/algocourse"
-            class="inline-block mt-4 text-sm font-medium text-brand-accent hover:underline"
-          >
-            View AlgoCourse &rarr;
-          </a>
-        </div>
-      </div>
+      )}
     </div>
   </div>
 </BaseLayout>

--- a/src/sanity/schemas/programme.ts
+++ b/src/sanity/schemas/programme.ts
@@ -38,6 +38,25 @@ export default defineType({
       type: "array",
       of: [{ type: "string" }],
     }),
+    defineField({
+      name: "curriculum",
+      title: "Curriculum",
+      description: "Structured curriculum items displayed in a grid (e.g. weekly topics)",
+      type: "array",
+      of: [
+        {
+          type: "object",
+          fields: [
+            defineField({ name: "label", title: "Label", type: "string", description: "e.g. 'Week 1' or '01'" }),
+            defineField({ name: "title", title: "Title", type: "string" }),
+            defineField({ name: "description", title: "Description", type: "text", rows: 2 }),
+          ],
+          preview: {
+            select: { title: "title", subtitle: "label" },
+          },
+        },
+      ],
+    }),
     defineField({ name: "sortOrder", title: "Sort Order", type: "number", initialValue: 99 }),
   ],
   orderings: [{ title: "Sort Order", name: "sortOrder", by: [{ field: "sortOrder", direction: "asc" }] }],


### PR DESCRIPTION
## Summary
- Replaced hardcoded content in AlgoCourse and Bootcamp pages with Sanity queries
- Added `curriculum` array field to the programme schema for structured grid layout
- One-time import scripts preserve all existing content (weeks, topics, stats, highlights)
- All programme pages now consistently pull content from Sanity

Closes #18

## Test plan
- [ ] Verify `/programmes/algocourse` renders 8-week curriculum grid, stats, highlights from Sanity
- [ ] Verify `/programmes/bootcamp` renders 4-topic grid, highlights, and CTA from Sanity
- [ ] Verify `/programmes` index still shows correct cards for both
- [ ] Confirm other programme pages are unaffected
- [ ] Test in Safari, Chrome, and Edge (light and dark mode)
- [ ] Verify curriculum field is editable in Sanity Studio