### PR TITLE
Fix sponsor logo visibility on dark backgrounds

### DIFF
--- a/src/components/content/SponsorLogo.astro
+++ b/src/components/content/SponsorLogo.astro
@@ -4,21 +4,15 @@ interface Props {
   logo: string;
   description?: string;
   websiteUrl?: string;
-  /** Use "light" on dark backgrounds (white card), "dark" on light backgrounds */
-  variant?: "light" | "dark";
 }
 
-const { name, logo, description, websiteUrl, variant = "light" } = Astro.props;
+const { name, logo, description, websiteUrl } = Astro.props;
 const Tag = websiteUrl ? "a" : "div";
 const linkProps = websiteUrl ? { href: websiteUrl, target: "_blank", rel: "noopener noreferrer" } : {};
-
-const cardClass = variant === "light"
-  ? "bg-white/5 border border-white/20"
-  : "bg-white/10 rounded-lg";
 ---
 
 <Tag {...linkProps} class="sponsor-card relative group">
-  <div class={`flex items-center justify-center h-20 rounded-lg px-4 transition-shadow hover:shadow-md ${cardClass}`}>
+  <div class="flex items-center justify-center h-20 rounded-lg px-4 transition-shadow hover:shadow-md bg-white">
     {logo ? (
       <img
         src={logo}
@@ -27,7 +21,7 @@ const cardClass = variant === "light"
         class="max-h-12 max-w-[140px] w-auto h-auto object-contain"
       />
     ) : (
-      <span class="text-sm font-semibold text-brand-foreground-muted">{name}</span>
+      <span class="text-sm font-semibold text-gray-500">{name}</span>
     )}
   </div>
   <div class="sponsor-tooltip absolute bottom-full left-1/2 -translate-x-1/2 mb-2 bg-brand-primary text-brand-foreground text-xs rounded-lg px-4 py-2.5 shadow-lg pointer-events-none z-10 w-48 text-center">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -97,7 +97,7 @@ const organizationJsonLd = {
       <div class="max-w-3xl">
         <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold tracking-tight leading-tight">
           Imperial College&apos;s Premier Society for{" "}
-          <span class="text-brand-accent">Aspiring Traders</span>
+          <span class="text-brand-accent whitespace-nowrap">Aspiring Traders</span>
         </h1>
         <p class="mt-6 text-lg text-brand-foreground leading-relaxed max-w-2xl">
           Building the next generation of quantitative traders, researchers,
@@ -226,7 +226,7 @@ const organizationJsonLd = {
         </p>
         <div class="mt-10 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-6 max-w-5xl mx-auto">
           {sponsors.map((s) => (
-            <SponsorLogo {...s} variant="dark" />
+            <SponsorLogo {...s} />
           ))}
         </div>
         <div class="mt-8">

--- a/src/pages/programmes/algothon.astro
+++ b/src/pages/programmes/algothon.astro
@@ -176,7 +176,6 @@ const editions = await client.fetch<AlgothonEdition[]>(
                           logo={s.logo?.asset?.url || ""}
                           description={s.description}
                           websiteUrl={s.websiteUrl}
-                          variant="light"
                         />
                       ))}
                     </div>

--- a/src/pages/sponsors.astro
+++ b/src/pages/sponsors.astro
@@ -96,7 +96,7 @@ const allTiers: { heading: string; tiers: TierConfig[] }[] = [
                 </p>
                 <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
                   {t.sponsors.map((s) => (
-                    <SponsorLogo {...s} variant="light" />
+                    <SponsorLogo {...s} />
                   ))}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Replace translucent card backgrounds with solid white (`bg-white`) so all sponsor logos are clearly visible
- Remove the `variant` prop from SponsorLogo for one consistent card style site-wide
- Prevent "Aspiring Traders" from wrapping in the hero heading

Closes #20

## Test plan
- [ ] Verify sponsor logos are clearly visible on the sponsors page
- [ ] Verify sponsor logos look correct on the homepage
- [ ] Verify sponsor logos look correct on the algothon page
- [ ] Check hero heading wraps cleanly at all viewport widths
- [ ] Test in Safari, Chrome, and Edge (light and dark mode)