### PR TITLE
Migrate About page content to Sanity

### DIFF
--- a/scripts/create-about-page.mjs
+++ b/scripts/create-about-page.mjs
@@ -1,0 +1,70 @@
+// One-time script to create the About Page document in Sanity.
+// Usage: SANITY_TOKEN=<token> node scripts/create-about-page.mjs
+
+import "dotenv/config";
+import { createClient } from "@sanity/client";
+
+const client = createClient({
+  projectId: "bd3zp068",
+  dataset: "production",
+  apiVersion: "2024-01-01",
+  useCdn: false,
+  token: process.env.SANITY_TOKEN,
+});
+
+if (!process.env.SANITY_TOKEN) {
+  console.error("Set SANITY_TOKEN env var (create one at sanity.io/manage -> API -> Tokens)");
+  process.exit(1);
+}
+
+const doc = {
+  _id: "aboutPage",
+  _type: "aboutPage",
+  mission:
+    "We exist to bridge the gap between academic knowledge and industry practice. Through our educational programmes, flagship competitions, and student-managed quantitative fund, we give members the skills, experience, and connections they need to launch careers in quantitative finance.",
+  pillars: [
+    {
+      _key: "educate",
+      title: "Educate",
+      description:
+        "Bootcamp, AlgoCourse, Markets 101, and weekly quant sessions prepare members for careers and interviews in trading and quant research.",
+    },
+    {
+      _key: "compete",
+      title: "Compete",
+      description:
+        "Algothon, Estimathon, and our internal QTC competition give members hands-on trading experience in competitive settings.",
+    },
+    {
+      _key: "invest",
+      title: "Invest",
+      description:
+        "Queen's Tower Capital is our student-managed quantitative fund, where analysts build and execute real trading strategies across Market Making, Market Taking, and Options divisions.",
+    },
+    {
+      _key: "connect",
+      title: "Connect",
+      description:
+        "We partner with {partners} leading firms to bring industry insight, career opportunities, and mentorship to our members.",
+    },
+  ],
+};
+
+async function main() {
+  const existing = await client.fetch(`*[_type == "aboutPage"][0]{ _id }`);
+
+  if (existing) {
+    console.log(`About page already exists (${existing._id}), updating...`);
+    await client.createOrReplace({ ...doc, _id: existing._id });
+  } else {
+    console.log("Creating About page document...");
+    await client.createOrReplace(doc);
+  }
+
+  console.log("Done! About page content created in Sanity.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -1,8 +1,14 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import { client } from "@/lib/sanity";
 import { getStats } from "@/lib/content";
 
 const stats = await getStats();
+
+const about = await client.fetch<{
+  mission?: string;
+  pillars?: Array<{ title: string; description: string }>;
+}>(`*[_type == "aboutPage"][0]{ mission, pillars }`);
 ---
 
 <BaseLayout
@@ -37,53 +43,30 @@ const stats = await getStats();
     </div>
 
     <div class="mt-16 max-w-3xl space-y-6 text-brand-foreground leading-relaxed">
-      <h2 class="text-2xl font-bold text-brand-foreground">Our Mission</h2>
-      <p>
-        We exist to bridge the gap between academic knowledge and industry
-        practice. Through our educational programmes, flagship competitions,
-        and student-managed quantitative fund, we give members the skills,
-        experience, and connections they need to launch careers in
-        quantitative finance.
-      </p>
+      {about?.mission && (
+        <>
+          <h2 class="text-2xl font-bold text-brand-foreground">Our Mission</h2>
+          <p>{about.mission}</p>
+        </>
+      )}
 
-      <h2 class="text-2xl font-bold text-brand-foreground mt-10">
-        What We Do
-      </h2>
-      <ul class="space-y-3">
-        <li class="flex gap-3">
-          <span class="text-brand-accent font-bold">01</span>
-          <span>
-            <strong>Educate</strong> - Bootcamp, AlgoCourse, Markets 101,
-            and weekly quant sessions prepare members for careers and
-            interviews in trading and quant research.
-          </span>
-        </li>
-        <li class="flex gap-3">
-          <span class="text-brand-accent font-bold">02</span>
-          <span>
-            <strong>Compete</strong> - Algothon, Estimathon, and our internal
-            QTC competition give members hands-on trading experience in
-            competitive settings.
-          </span>
-        </li>
-        <li class="flex gap-3">
-          <span class="text-brand-accent font-bold">03</span>
-          <span>
-            <strong>Invest</strong> - Queen&apos;s Tower Capital is our
-            student-managed quantitative fund, where analysts build and
-            execute real trading strategies across Market Making, Market
-            Taking, and Options divisions.
-          </span>
-        </li>
-        <li class="flex gap-3">
-          <span class="text-brand-accent font-bold">04</span>
-          <span>
-            <strong>Connect</strong> - We partner with {stats.partners}{" "}
-            leading firms to bring industry insight, career opportunities,
-            and mentorship to our members.
-          </span>
-        </li>
-      </ul>
+      {about?.pillars && about.pillars.length > 0 && (
+        <>
+          <h2 class="text-2xl font-bold text-brand-foreground mt-10">
+            What We Do
+          </h2>
+          <ul class="space-y-3">
+            {about.pillars.map((item, i) => (
+              <li class="flex gap-3">
+                <span class="text-brand-accent font-bold">{String(i + 1).padStart(2, "0")}</span>
+                <span>
+                  <strong>{item.title}</strong> - {item.description.replace("{partners}", stats.partners)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
     </div>
 
     <div class="mt-12">

--- a/src/sanity/schemas/aboutPage.ts
+++ b/src/sanity/schemas/aboutPage.ts
@@ -1,0 +1,37 @@
+import { defineType, defineField } from "sanity";
+
+export default defineType({
+  name: "aboutPage",
+  title: "About Page",
+  type: "document",
+  fields: [
+    defineField({
+      name: "mission",
+      title: "Mission Statement",
+      type: "text",
+      rows: 4,
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "pillars",
+      title: "What We Do",
+      description: "Numbered items describing the society's core activities",
+      type: "array",
+      of: [
+        {
+          type: "object",
+          fields: [
+            defineField({ name: "title", title: "Title", type: "string", validation: (r) => r.required() }),
+            defineField({ name: "description", title: "Description", type: "text", rows: 2, validation: (r) => r.required() }),
+          ],
+          preview: {
+            select: { title: "title", subtitle: "description" },
+          },
+        },
+      ],
+    }),
+  ],
+  preview: {
+    prepare: () => ({ title: "About Page" }),
+  },
+});

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -8,5 +8,6 @@ import programme from "./programme";
 import siteConfig from "./siteConfig";
 import witEvent from "./witEvent";
 import algothon from "./algothon";
+import aboutPage from "./aboutPage";
 
-export const schemaTypes = [post, event, teamMember, sponsor, sponsorAlgothon, resource, programme, siteConfig, witEvent, algothon];
+export const schemaTypes = [post, event, teamMember, sponsor, sponsorAlgothon, resource, programme, siteConfig, witEvent, algothon, aboutPage];


### PR DESCRIPTION
## Summary
- New `aboutPage` Sanity document type for mission statement and "What We Do" pillars
- About page now fetches content from Sanity instead of hardcoding it
- Supports `{partners}` token in pillar descriptions, replaced with live sponsor count at build time
- One-time import script preserving existing content

Closes #22

## Test plan
- [ ] Verify `/about` renders mission statement and all 4 pillars from Sanity
- [ ] Verify Connect pillar shows dynamic partner count
- [ ] Verify stats grid still works (already Sanity-driven)
- [ ] Test in Safari, Chrome, and Edge (light and dark mode)