### PR TITLE
Update docs and add docs check to issueclose skill

### DIFF
--- a/.claude/skills/issueclose/SKILL.md
+++ b/.claude/skills/issueclose/SKILL.md
@@ -11,7 +11,12 @@ When the user wants to wrap up work on the current branch, follow these steps:
    - Run `git diff --stat` to summarise what changed
    - If there are no changes, tell the user and stop
 
-2. **Commit:**
+2. **Check documentation:**
+   - If the changes affect Sanity schemas, shared utilities, or project structure, update `CLAUDE.md`
+   - If the changes affect the spec or task tracker, update `spec.md` and/or `todo.md`
+   - Stage any doc updates alongside the code changes
+
+3. **Commit:**
    - Stage the relevant files (not `.env`, credentials, or generated files)
    - Write a concise commit message in imperative mood describing the "why"
    - Use a HEREDOC for the message

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,10 +83,12 @@ All schemas live in `src/sanity/schemas/`. The index at `src/sanity/schemas/inde
 | `sponsor` | document | Sponsors (`logo` is a Sanity image asset) |
 | `sponsorAlgothon` | document | Algothon-specific sponsors (same fields as `sponsor`) |
 | `resource` | document | Resources |
-| `programme` | document | Programmes (stats are value/label pairs) |
+| `programme` | document | Programmes (stats are value/label pairs, optional curriculum grid, highlights) |
 | `algothon` | document | Algothon editions (year, images carousel, sponsors, participants, recap) |
 | `siteConfig` | document | Site-wide config and stats |
 | `witEvent` | document | WIT recurring event types (title + description) |
+| `aboutPage` | document | About page content (mission statement, "What We Do" pillars). Singleton. Pillar descriptions support `{partners}` token for live sponsor count. |
+| `joinPage` | document | Join page content (heading, intro, CTA label/URL/note). Singleton. Programmes and events are auto-populated from their respective document types. |
 
 ### Schema Change Workflow
 


### PR DESCRIPTION
## Summary
- Add `aboutPage`, `joinPage` schemas and `curriculum` field to CLAUDE.md schema table
- Add documentation check step to issueclose skill so CLAUDE.md stays current

## Test plan
- [ ] Verify CLAUDE.md schema table is accurate
- [ ] Verify issueclose skill includes docs check step