### PR TITLE
Rename ICATS to AlgoSoc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# ICATS Website
+# AlgoSoc Website
 
 Astro 6 static site for the Imperial College Algorithmic Trading Society. Must be live by **22 September 2026**.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ICATS Website
+# AlgoSoc Website
 
-Astro + Sanity CMS rebuild of the ICATS website. Static output hosted on S3 + CloudFront, with automatic rebuilds triggered by Sanity content changes.
+Astro + Sanity CMS rebuild of the AlgoSoc website. Static output hosted on S3 + CloudFront, with automatic rebuilds triggered by Sanity content changes.
 
 **Preview:** https://icats.z16.web.core.windows.net/
 
@@ -12,7 +12,7 @@ Astro + Sanity CMS rebuild of the ICATS website. Static output hosted on S3 + Cl
 |-------|-----------|
 | Framework | Astro 6 (static output), TypeScript strict |
 | Styling | Tailwind CSS 4 |
-| CMS | Sanity (hosted Studio at icats.sanity.studio) |
+| CMS | Sanity (hosted Studio at algosoc.sanity.studio) |
 | Fonts | Archivo (headings), Albert Sans (body) |
 | Hosting | Azure Blob Storage (static website) |
 | CI/CD | GitHub Actions (build + deploy on content change) |
@@ -41,7 +41,7 @@ Ask a team member for the values, or find them in the Sanity dashboard (manage.s
 
 ## Sanity Studio
 
-- **URL**: https://icats.sanity.studio/
+- **URL**: https://algosoc.sanity.studio/
 
 Content types: Blog Posts, Events, Team Members, Sponsors, Resources, Programmes, WIT Events, Site Config (singleton).
 

--- a/brand.md
+++ b/brand.md
@@ -1,4 +1,4 @@
-# ICATS Brand Guidelines
+# AlgoSoc Brand Guidelines
 
 Source of truth for colours and typography. CSS custom properties are defined in `src/styles/globals.css`. A visual preview is at `/brand`.
 

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -3,8 +3,8 @@ import { structureTool } from "sanity/structure";
 import { schemaTypes } from "./src/sanity/schemas";
 
 export default defineConfig({
-  name: "icats",
-  title: "ICATS Website",
+  name: "algosoc",
+  title: "AlgoSoc Website",
   projectId: "bd3zp068",
   dataset: "production",
   plugins: [structureTool()],

--- a/scripts/create-join-page.mjs
+++ b/scripts/create-join-page.mjs
@@ -20,7 +20,7 @@ if (!process.env.SANITY_TOKEN) {
 const doc = {
   _id: "joinPage",
   _type: "joinPage",
-  heading: "Join ICATS",
+  heading: "Join AlgoSoc",
   intro:
     "Become part of Imperial College's largest algorithmic trading and quantitative finance community. Membership gives you access to all our programmes, events, and resources.",
   ctaLabel: "Join via Imperial College Union",

--- a/scripts/create-weekly-quant-sessions.mjs
+++ b/scripts/create-weekly-quant-sessions.mjs
@@ -44,7 +44,7 @@ const doc = {
         {
           _type: "span",
           _key: "s2",
-          text: "Weekly Quant Sessions are informal, collaborative meetups where ICATS members work through quantitative finance problems together. Each session focuses on a different topic, from brainteasers and probability puzzles to real-world strategy development and data analysis.",
+          text: "Weekly Quant Sessions are informal, collaborative meetups where AlgoSoc members work through quantitative finance problems together. Each session focuses on a different topic, from brainteasers and probability puzzles to real-world strategy development and data analysis.",
         },
       ],
       markDefs: [],

--- a/spec.md
+++ b/spec.md
@@ -1,4 +1,4 @@
-# ICATS Website Rebuild - Implementation Plan
+# AlgoSoc Website Rebuild - Implementation Plan
 
 ## Context
 
@@ -16,7 +16,7 @@ The current algosoc.com is a static HTML site hosted on **AWS (S3 + CloudFront +
 |-------|-----------|------|
 | Front-end | **Astro 6** (static output), TypeScript, Tailwind CSS 4 | Free |
 | Hosting | **AWS Amplify** | Free tier |
-| CMS | **Sanity** (hosted, project bd3zp068, Studio at icats.sanity.studio) | Free tier |
+| CMS | **Sanity** (hosted, project bd3zp068, Studio at algosoc.sanity.studio) | Free tier |
 | Database | **AWS RDS PostgreSQL** (free tier) or **Supabase** (hosted on AWS) | Free tier or ~$15/mo |
 | Auth | TBD for Fantasy League - email OTP restricted to @ic.ac.uk (MVP), Entra ID SSO later | Free |
 | Storage | **S3** (already exists) | Pennies/month |
@@ -39,7 +39,7 @@ algosoc.com/
   /blog                        Blog listing (newsletter, market recap, research)
   /blog/[slug]                 Individual post (rich text, LaTeX, embedded charts)
   /resources                   Member resources (bootcamp, notebooks, problem sets, reading lists)
-  /sponsors                    ICATS tiers (Platinum/Gold/Silver/Bronze) + ICWiT tiers
+  /sponsors                    AlgoSoc tiers (Platinum/Gold/Silver/Bronze) + ICWiT tiers
   /wit                         ICWiT section (mission, leadership, sponsors, events)
   /fantasy-league              Landing page + link to league.algosoc.com
   /leaderboard                 Points leaderboard (public)

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -6,7 +6,7 @@ const year = new Date().getFullYear();
   <div class="relative z-10 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
       <div class="md:col-span-2">
-        <h3 class="text-lg font-bold text-brand-foreground mb-2">ICATS</h3>
+        <h3 class="text-lg font-bold text-brand-foreground mb-2">AlgoSoc</h3>
         <p class="text-sm leading-relaxed">
           Imperial College Algorithmic Trading Society. London's premier
           university society for aspiring traders, quant researchers, and

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -6,7 +6,7 @@ import { navItems } from "@/lib/data";
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
     <div class="flex h-16 items-center justify-between">
       <a href="/" class="flex items-center gap-2">
-        <span class="text-xl font-bold text-brand-foreground tracking-tight">ICATS</span>
+        <span class="text-xl font-bold text-brand-foreground tracking-tight">AlgoSoc</span>
         <span class="hidden sm:inline text-sm text-brand-muted">
           Imperial College Algorithmic Trading Society
         </span>
@@ -25,7 +25,7 @@ import { navItems } from "@/lib/data";
           href="/join"
           class="ml-3 px-4 py-2 text-sm font-medium text-brand-foreground bg-brand-accent hover:bg-amber-400 rounded-md transition-colors"
         >
-          Join ICATS
+          Join AlgoSoc
         </a>
       </nav>
 
@@ -59,7 +59,7 @@ import { navItems } from "@/lib/data";
         href="/join"
         class="block mt-2 px-3 py-2 text-sm font-medium text-brand-foreground bg-brand-accent hover:bg-amber-400 rounded-md text-center"
       >
-        Join ICATS
+        Join AlgoSoc
       </a>
     </div>
   </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,14 +13,14 @@ interface Props {
 }
 
 const {
-  title = "ICATS - Imperial College Algorithmic Trading Society",
+  title = "AlgoSoc - Imperial College Algorithmic Trading Society",
   description = "Imperial College London's premier society for algorithmic trading, quantitative finance, and market technology. Home to Algothon, Queen's Tower Capital, and AlgoCourse.",
   canonical,
   ogType = "website",
   ogImage = "/og-image.png",
 } = Astro.props;
 
-const fullTitle = title.includes("ICATS") ? title : `${title} | ICATS`;
+const fullTitle = title.includes("AlgoSoc") ? title : `${title} | AlgoSoc`;
 ---
 
 <!doctype html>
@@ -31,12 +31,12 @@ const fullTitle = title.includes("ICATS") ? title : `${title} | ICATS`;
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>{fullTitle}</title>
     <meta name="description" content={description} />
-    <meta name="keywords" content="Imperial College, algorithmic trading, ICATS, quantitative finance, Queen's Tower Capital, Algothon, quant finance society" />
+    <meta name="keywords" content="Imperial College, algorithmic trading, AlgoSoc, quantitative finance, Queen's Tower Capital, Algothon, quant finance society" />
     {canonical && <link rel="canonical" href={canonical} />}
 
     <!-- Open Graph -->
     <meta property="og:type" content={ogType} />
-    <meta property="og:site_name" content="ICATS - Imperial College Algorithmic Trading Society" />
+    <meta property="og:site_name" content="AlgoSoc - Imperial College Algorithmic Trading Society" />
     <meta property="og:title" content={fullTitle} />
     <meta property="og:description" content={description} />
     <meta property="og:url" content={Astro.url.href} />
@@ -52,7 +52,7 @@ const fullTitle = title.includes("ICATS") ? title : `${title} | ICATS`;
     <meta name="twitter:image" content={new URL(ogImage, Astro.site || Astro.url).href} />
 
     <!-- RSS -->
-    <link rel="alternate" type="application/rss+xml" title="ICATS RSS Feed" href="/rss.xml" />
+    <link rel="alternate" type="application/rss+xml" title="AlgoSoc RSS Feed" href="/rss.xml" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/pages/about/committee.astro
+++ b/src/pages/about/committee.astro
@@ -37,7 +37,7 @@ const witCommittee = members.filter((m) => m.division === "icwit");
 
 <BaseLayout
   title="Committee"
-  description="Meet the ICATS committee: the team running Imperial College's algorithmic trading society across trading, technology, events, marketing, and operations."
+  description="Meet the AlgoSoc committee: the team running Imperial College's algorithmic trading society across trading, technology, events, marketing, and operations."
   canonical="/about/committee"
 >
   <div class="bg-brand-primary">
@@ -46,12 +46,12 @@ const witCommittee = members.filter((m) => m.division === "icwit");
       Our Committees
     </h1>
     <p class="mt-2 text-brand-foreground-muted">
-      The ICATS &amp; ICWiT committees driving our programmes, events, and
+      The AlgoSoc &amp; ICWiT committees driving our programmes, events, and
       partnerships.
     </p>
 
     <h2 class="text-xl font-bold text-brand-foreground mt-12 mb-6">
-      ICATS Leadership
+      AlgoSoc Leadership
     </h2>
     {committee.length > 0 ? (
       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -13,16 +13,16 @@ const about = await client.fetch<{
 
 <BaseLayout
   title="About"
-  description="Learn about ICATS, Imperial College's algorithmic trading society. Our mission, history, and what we offer to aspiring quant traders and technologists."
+  description="Learn about AlgoSoc, Imperial College's algorithmic trading society. Our mission, history, and what we offer to aspiring quant traders and technologists."
   canonical="/about"
 >
   <div class="bg-brand-primary">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
     <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
-      About ICATS
+      About AlgoSoc
     </h1>
     <p class="mt-4 text-lg text-brand-foreground-muted max-w-3xl leading-relaxed">
-      The Imperial College Algorithmic Trading Society (ICATS) is London&apos;s
+      The Imperial College Algorithmic Trading Society (AlgoSoc) is London&apos;s
       premier university society for students passionate about quantitative
       finance, algorithmic trading, and market technology. Founded in {stats.founded},
       we&apos;ve grown to over {stats.members} members.

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -44,7 +44,7 @@ const articleJsonLd = {
   ...(post.featuredImage?.asset?.url && { image: post.featuredImage.asset.url }),
   publisher: {
     "@type": "Organization",
-    name: "ICATS - Imperial College Algorithmic Trading Society",
+    name: "AlgoSoc - Imperial College Algorithmic Trading Society",
     url: "https://algosoc.com",
   },
   mainEntityOfPage: `https://algosoc.com/blog/${slug}`,
@@ -53,7 +53,7 @@ const articleJsonLd = {
 
 <BaseLayout
   title={post.title}
-  description={post.excerpt || `Read "${post.title}" on the ICATS blog.`}
+  description={post.excerpt || `Read "${post.title}" on the AlgoSoc blog.`}
   canonical={`/blog/${slug}`}
   ogType="article"
 >

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -22,14 +22,14 @@ const posts = allPosts
 
 <BaseLayout
   title="Blog"
-  description="ICATS blog: market recaps, research articles, newsletters, and announcements from Imperial College's algorithmic trading society."
+  description="AlgoSoc blog: market recaps, research articles, newsletters, and announcements from Imperial College's algorithmic trading society."
   canonical="/blog"
 >
   <div class="bg-brand-primary">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
       <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">Blog</h1>
     <p class="mt-2 text-brand-foreground-muted max-w-xl">
-      Weekly market recaps, research notes, and newsletters from the ICATS
+      Weekly market recaps, research notes, and newsletters from the AlgoSoc
       committee.
     </p>
 

--- a/src/pages/brand.astro
+++ b/src/pages/brand.astro
@@ -51,16 +51,16 @@ const colourGroups: { title: string; swatches: Swatch[] }[] = [
 
 <BaseLayout
   title="Brand Guidelines"
-  description="ICATS brand guidelines: colours, typography, and logo usage for consistent society branding."
+  description="AlgoSoc brand guidelines: colours, typography, and logo usage for consistent society branding."
   canonical="/brand"
 >
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
     <h1 class="text-3xl sm:text-4xl font-bold text-brand-foreground">
-      ICATS Brand Guidelines
+      AlgoSoc Brand Guidelines
     </h1>
     <p class="mt-2 text-brand-foreground-muted max-w-2xl">
       Single source of truth for colours, typography, and visual identity
-      across all ICATS and ICWiT materials. Defined in
+      across all AlgoSoc and ICWiT materials. Defined in
       <code class="text-sm bg-white/10 px-1.5 py-0.5 rounded">src/styles/globals.css</code>.
     </p>
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -4,7 +4,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 
 <BaseLayout
   title="Contact"
-  description="Get in touch with ICATS, Imperial College's algorithmic trading society. Reach out for sponsorship, collaboration, or general enquiries."
+  description="Get in touch with AlgoSoc, Imperial College's algorithmic trading society. Reach out for sponsorship, collaboration, or general enquiries."
   canonical="/contact"
 >
   <div class="bg-brand-primary">
@@ -14,7 +14,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
           Contact Us
         </h1>
         <p class="mt-2 text-brand-foreground-muted">
-          Get in touch with the ICATS committee. We&apos;d love to hear from you.
+          Get in touch with the AlgoSoc committee. We&apos;d love to hear from you.
         </p>
 
         <div class="mt-8 space-y-4">

--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -37,7 +37,7 @@ const eventsJsonLd = events.map((e) => ({
   }),
   organizer: {
     "@type": "Organization",
-    name: "ICATS - Imperial College Algorithmic Trading Society",
+    name: "AlgoSoc - Imperial College Algorithmic Trading Society",
     url: "https://algosoc.com",
   },
 }));
@@ -45,7 +45,7 @@ const eventsJsonLd = events.map((e) => ({
 
 <BaseLayout
   title="Events"
-  description="Upcoming ICATS events at Imperial College: competitions, workshops, quant sessions, company presentations, and socials throughout the academic year."
+  description="Upcoming AlgoSoc events at Imperial College: competitions, workshops, quant sessions, company presentations, and socials throughout the academic year."
   canonical="/events"
 >
   <div class="bg-brand-primary">

--- a/src/pages/fantasy-league.astro
+++ b/src/pages/fantasy-league.astro
@@ -31,7 +31,7 @@ const features = [
 
 <BaseLayout
   title="Fantasy League"
-  description="ICATS Fantasy League: build and manage a virtual trading portfolio. Compete against fellow Imperial students in simulated markets."
+  description="AlgoSoc Fantasy League: build and manage a virtual trading portfolio. Compete against fellow Imperial students in simulated markets."
   canonical="/fantasy-league"
 >
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -67,8 +67,8 @@ const sponsors = allSponsors.map((s) => ({
 const organizationJsonLd = {
   "@context": "https://schema.org",
   "@type": "Organization",
-  name: "ICATS - Imperial College Algorithmic Trading Society",
-  alternateName: "ICATS",
+  name: "AlgoSoc - Imperial College Algorithmic Trading Society",
+  alternateName: "AlgoSoc",
   url: "https://algosoc.com",
   description: "Imperial College London's premier society for algorithmic trading, quantitative finance, and market technology.",
   parentOrganization: {
@@ -109,7 +109,7 @@ const organizationJsonLd = {
             href="/join"
             class="px-6 py-3 text-sm font-semibold bg-brand-accent text-brand-primary rounded-lg hover:bg-amber-400 transition-colors btn-glow"
           >
-            Join ICATS
+            Join AlgoSoc
           </a>
           <a
             href="/programmes"

--- a/src/pages/join.astro
+++ b/src/pages/join.astro
@@ -32,7 +32,7 @@ const [joinPage, programmes, upcomingEvents, stats] = await Promise.all([
   getStats(),
 ]);
 
-const heading = joinPage?.heading || "Join ICATS";
+const heading = joinPage?.heading || "Join AlgoSoc";
 const intro = joinPage?.intro || "";
 const ctaLabel = joinPage?.ctaLabel || "Join via Imperial College Union";
 const ctaUrl = joinPage?.ctaUrl || "#";
@@ -40,8 +40,8 @@ const ctaNote = joinPage?.ctaNote || "";
 ---
 
 <BaseLayout
-  title="Join ICATS"
-  description="Join ICATS and become part of Imperial College's algorithmic trading community. Access competitions, courses, networking, and career opportunities in quant finance."
+  title="Join AlgoSoc"
+  description="Join AlgoSoc and become part of Imperial College's algorithmic trading community. Access competitions, courses, networking, and career opportunities in quant finance."
   canonical="/join"
 >
   <div class="bg-brand-primary">

--- a/src/pages/leaderboard.astro
+++ b/src/pages/leaderboard.astro
@@ -19,7 +19,7 @@ const categories = ["Overall", "Events", "Competitions", "Fantasy League"];
 
 <BaseLayout
   title="Leaderboard"
-  description="ICATS member leaderboard: track rankings across competitions, courses, and society engagement."
+  description="AlgoSoc member leaderboard: track rankings across competitions, courses, and society engagement."
   canonical="/leaderboard"
 >
   <div class="bg-brand-primary">
@@ -28,7 +28,7 @@ const categories = ["Overall", "Events", "Competitions", "Fantasy League"];
         Leaderboard
       </h1>
       <p class="mt-2 text-brand-foreground-muted max-w-xl">
-        ICATS engagement leaderboard. Earn points by attending events, competing,
+        AlgoSoc engagement leaderboard. Earn points by attending events, competing,
         and contributing.
       </p>
 

--- a/src/pages/programmes/algothon.astro
+++ b/src/pages/programmes/algothon.astro
@@ -42,7 +42,7 @@ const editions = await client.fetch<AlgothonEdition[]>(
 
 <BaseLayout
   title="Algothon"
-  description="Algothon is ICATS' flagship annual inter-university algorithmic trading hackathon. Teams build and submit trading strategies, competing for prizes from top firms."
+  description="Algothon is AlgoSoc's flagship annual inter-university algorithmic trading hackathon. Teams build and submit trading strategies, competing for prizes from top firms."
   canonical="/programmes/algothon"
 >
   <div class="bg-brand-primary">

--- a/src/pages/programmes/bootcamp.astro
+++ b/src/pages/programmes/bootcamp.astro
@@ -20,7 +20,7 @@ const bodyHtml = programme?.body ? toHTML(programme.body) : "";
 
 <BaseLayout
   title="Bootcamp"
-  description="ICATS Bootcamp: a pre-requisite crash course for AlgoCourse, covering foundational concepts in quantitative trading. Accessible to all backgrounds."
+  description="AlgoSoc Bootcamp: a pre-requisite crash course for AlgoCourse, covering foundational concepts in quantitative trading. Accessible to all backgrounds."
   canonical="/programmes/bootcamp"
 >
   <div class="bg-brand-primary min-h-[60vh]">

--- a/src/pages/programmes/index.astro
+++ b/src/pages/programmes/index.astro
@@ -14,7 +14,7 @@ const programmes = await client.fetch<Array<{
 
 <BaseLayout
   title="Programmes"
-  description="ICATS programmes: Algothon, AlgoCourse, Queen's Tower Capital, and more. Education and hands-on experience in algorithmic trading and quantitative finance."
+  description="AlgoSoc programmes: Algothon, AlgoCourse, Queen's Tower Capital, and more. Education and hands-on experience in algorithmic trading and quantitative finance."
   canonical="/programmes"
 >
   <div class="bg-brand-primary">

--- a/src/pages/programmes/queens-tower-capital.astro
+++ b/src/pages/programmes/queens-tower-capital.astro
@@ -19,7 +19,7 @@ const bodyHtml = programme?.body ? toHTML(programme.body) : "";
 
 <BaseLayout
   title="Queen's Tower Capital"
-  description="ICATS' student-managed quantitative fund. Develop, backtest, and implement trading strategies with real portfolio management and risk assessment."
+  description="AlgoSoc's student-managed quantitative fund. Develop, backtest, and implement trading strategies with real portfolio management and risk assessment."
   canonical="/programmes/queens-tower-capital"
 >
   <div class="bg-brand-primary min-h-[60vh]">

--- a/src/pages/resources.astro
+++ b/src/pages/resources.astro
@@ -24,7 +24,7 @@ const resources = allResources.map((r) => ({
 
 <BaseLayout
   title="Resources"
-  description="ICATS learning resources: career guides, bootcamp materials, AlgoCourse content, reading lists, and quant session recordings for aspiring traders."
+  description="AlgoSoc learning resources: career guides, bootcamp materials, AlgoCourse content, reading lists, and quant session recordings for aspiring traders."
   canonical="/resources"
 >
   <div class="bg-brand-primary">
@@ -34,7 +34,7 @@ const resources = allResources.map((r) => ({
     </h1>
     <p class="mt-2 text-brand-foreground-muted max-w-xl">
       Lecture slides, problem sets, code notebooks, and career guides for
-      ICATS members.
+      AlgoSoc members.
     </p>
 
     {resources.length === 0 ? (

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -45,8 +45,8 @@ export async function GET(context: APIContext) {
     .slice(0, 50);
 
   return rss({
-    title: "ICATS - Imperial College Algorithmic Trading Society",
-    description: "Blog posts, events, and updates from ICATS.",
+    title: "AlgoSoc - Imperial College Algorithmic Trading Society",
+    description: "Blog posts, events, and updates from AlgoSoc.",
     site: context.site!,
     items,
   });

--- a/src/pages/sponsors.astro
+++ b/src/pages/sponsors.astro
@@ -40,7 +40,7 @@ type TierConfig = {
 
 const allTiers: { heading: string; tiers: TierConfig[] }[] = [
   {
-    heading: "ICATS Sponsors",
+    heading: "AlgoSoc Sponsors",
     tiers: [
       { tier: "Platinum", label: "Exclusive naming rights on a flagship event, priority CV book access, dedicated newsletter feature, and branded presence across all channels.", amount: "Top tier", sponsors: platinum },
       { tier: "Gold", label: "Logo on all key materials, two sponsored events, CV book access, and featured newsletter post.", amount: "Mid tier", sponsors: gold },
@@ -61,7 +61,7 @@ const allTiers: { heading: string; tiers: TierConfig[] }[] = [
 
 <BaseLayout
   title="Sponsors"
-  description="ICATS industry partners and sponsors from leading quantitative finance and trading firms. Learn about sponsorship opportunities."
+  description="AlgoSoc industry partners and sponsors from leading quantitative finance and trading firms. Learn about sponsorship opportunities."
   canonical="/sponsors"
 >
   <div class="bg-brand-primary">
@@ -70,7 +70,7 @@ const allTiers: { heading: string; tiers: TierConfig[] }[] = [
         Our Sponsors
     </h1>
     <p class="mt-2 text-brand-foreground-muted max-w-xl">
-      ICATS is proudly supported by leading firms in quantitative finance,
+      AlgoSoc is proudly supported by leading firms in quantitative finance,
       algorithmic trading, and technology.
     </p>
 
@@ -108,7 +108,7 @@ const allTiers: { heading: string; tiers: TierConfig[] }[] = [
 
     <div class="mt-16 bg-white/5 rounded-xl p-8 text-center">
       <h2 class="text-xl font-bold text-brand-foreground">
-        Interested in Sponsoring ICATS?
+        Interested in Sponsoring AlgoSoc?
       </h2>
       <p class="mt-2 text-brand-foreground-muted max-w-md mx-auto">
         Partner with London&apos;s largest university algorithmic trading

--- a/src/pages/wit.astro
+++ b/src/pages/wit.astro
@@ -30,7 +30,7 @@ const events = await client.fetch<Array<{
         Imperial College Women in Trading
       </h1>
       <p class="mt-4 text-lg text-brand-foreground-muted max-w-3xl leading-relaxed">
-        ICWiT is a sub-society within ICATS dedicated to empowering women in
+        ICWiT is a sub-society within AlgoSoc dedicated to empowering women in
         quantitative finance, trading, and technology. With {stats.witMembers}{" "}
         members and {stats.witEvents} events, we provide a supportive
         community, mentorship, and career opportunities.

--- a/src/sanity/schemas/joinPage.ts
+++ b/src/sanity/schemas/joinPage.ts
@@ -9,7 +9,7 @@ export default defineType({
       name: "heading",
       title: "Heading",
       type: "string",
-      initialValue: "Join ICATS",
+      initialValue: "Join AlgoSoc",
       validation: (r) => r.required(),
     }),
     defineField({


### PR DESCRIPTION
## Summary
- Replaces all references to "ICATS" with "AlgoSoc" across 30 files: page content, meta descriptions, JSON-LD structured data, RSS feed, Sanity Studio config, import scripts, and documentation
- Sanity CMS content fields have been updated separately in the Studio

## Test plan
- [ ] `npm run build` succeeds
- [ ] Verify header/footer show "AlgoSoc" on all pages
- [ ] Check page titles in browser tabs say "AlgoSoc"
- [ ] Confirm RSS feed at /rss.xml uses the new name
- [ ] Sanity Studio loads at the updated config name